### PR TITLE
#427 Lazy operands for short-circuit evaluation of logic operators

### DIFF
--- a/src/main/java/com/ezylang/evalex/Expression.java
+++ b/src/main/java/com/ezylang/evalex/Expression.java
@@ -208,7 +208,8 @@ public class Expression {
 
   private EvaluationValue evaluateInfixOperator(ASTNode startNode, Token token)
       throws EvaluationException {
-    EvaluationValue left, right;
+    EvaluationValue left;
+    EvaluationValue right;
 
     OperatorIfc op = token.getOperatorDefinition();
     if (op.isOperandLazy()) {

--- a/src/main/java/com/ezylang/evalex/Expression.java
+++ b/src/main/java/com/ezylang/evalex/Expression.java
@@ -207,7 +207,7 @@ public class Expression {
   }
 
   private EvaluationValue evaluateInfixOperator(ASTNode startNode, Token token)
-          throws EvaluationException {
+      throws EvaluationException {
     EvaluationValue left, right;
 
     OperatorIfc op = token.getOperatorDefinition();

--- a/src/main/java/com/ezylang/evalex/Expression.java
+++ b/src/main/java/com/ezylang/evalex/Expression.java
@@ -19,6 +19,7 @@ import com.ezylang.evalex.config.ExpressionConfiguration;
 import com.ezylang.evalex.data.DataAccessorIfc;
 import com.ezylang.evalex.data.EvaluationValue;
 import com.ezylang.evalex.functions.FunctionIfc;
+import com.ezylang.evalex.operators.OperatorIfc;
 import com.ezylang.evalex.parser.*;
 import java.math.BigDecimal;
 import java.util.*;
@@ -122,14 +123,7 @@ public class Expression {
                 .evaluate(this, token, evaluateSubtree(startNode.getParameters().get(0)));
         break;
       case INFIX_OPERATOR:
-        result =
-            token
-                .getOperatorDefinition()
-                .evaluate(
-                    this,
-                    token,
-                    evaluateSubtree(startNode.getParameters().get(0)),
-                    evaluateSubtree(startNode.getParameters().get(1)));
+        result = evaluateInfixOperator(startNode, token);
         break;
       case ARRAY_INDEX:
         result = evaluateArrayIndex(startNode);
@@ -210,6 +204,21 @@ public class Expression {
     } else {
       throw EvaluationException.ofUnsupportedDataTypeInOperation(startNode.getToken());
     }
+  }
+
+  private EvaluationValue evaluateInfixOperator(ASTNode startNode, Token token)
+          throws EvaluationException {
+    EvaluationValue left, right;
+
+    OperatorIfc op = token.getOperatorDefinition();
+    if (op.isOperandLazy()) {
+      left = convertValue(startNode.getParameters().get(0));
+      right = convertValue(startNode.getParameters().get(1));
+    } else {
+      left = evaluateSubtree(startNode.getParameters().get(0));
+      right = evaluateSubtree(startNode.getParameters().get(1));
+    }
+    return op.evaluate(this, token, left, right);
   }
 
   /**

--- a/src/main/java/com/ezylang/evalex/operators/AbstractOperator.java
+++ b/src/main/java/com/ezylang/evalex/operators/AbstractOperator.java
@@ -46,7 +46,7 @@ public abstract class AbstractOperator implements OperatorIfc {
       this.type = OperatorType.INFIX_OPERATOR;
       this.precedence = infixAnnotation.precedence();
       this.leftAssociative = infixAnnotation.leftAssociative();
-      this.operandsLazy = infixAnnotation.isLazy();
+      this.operandsLazy = infixAnnotation.operandsLazy();
     } else if (prefixAnnotation != null) {
       this.type = PREFIX_OPERATOR;
       this.precedence = prefixAnnotation.precedence();

--- a/src/main/java/com/ezylang/evalex/operators/AbstractOperator.java
+++ b/src/main/java/com/ezylang/evalex/operators/AbstractOperator.java
@@ -30,6 +30,8 @@ public abstract class AbstractOperator implements OperatorIfc {
 
   private final boolean leftAssociative;
 
+  private final boolean operandsLazy;
+
   OperatorType type;
 
   /**
@@ -44,14 +46,17 @@ public abstract class AbstractOperator implements OperatorIfc {
       this.type = OperatorType.INFIX_OPERATOR;
       this.precedence = infixAnnotation.precedence();
       this.leftAssociative = infixAnnotation.leftAssociative();
+      this.operandsLazy = infixAnnotation.isLazy();
     } else if (prefixAnnotation != null) {
       this.type = PREFIX_OPERATOR;
       this.precedence = prefixAnnotation.precedence();
       this.leftAssociative = prefixAnnotation.leftAssociative();
+      this.operandsLazy = false;
     } else if (postfixAnnotation != null) {
       this.type = OperatorType.POSTFIX_OPERATOR;
       this.precedence = postfixAnnotation.precedence();
       this.leftAssociative = postfixAnnotation.leftAssociative();
+      this.operandsLazy = false;
     } else {
       throw new OperatorAnnotationNotFoundException(this.getClass().getName());
     }
@@ -65,6 +70,11 @@ public abstract class AbstractOperator implements OperatorIfc {
   @Override
   public boolean isLeftAssociative() {
     return leftAssociative;
+  }
+
+  @Override
+  public boolean isOperandLazy() {
+    return operandsLazy;
   }
 
   @Override

--- a/src/main/java/com/ezylang/evalex/operators/InfixOperator.java
+++ b/src/main/java/com/ezylang/evalex/operators/InfixOperator.java
@@ -32,4 +32,7 @@ public @interface InfixOperator {
 
   /** Operator associativity, defaults to <code>true</code>. */
   boolean leftAssociative() default true;
+
+  /** Operands are evaluated lazily, defaults to <code>false</code>. */
+  boolean operandsLazy() default false;
 }

--- a/src/main/java/com/ezylang/evalex/operators/OperatorIfc.java
+++ b/src/main/java/com/ezylang/evalex/operators/OperatorIfc.java
@@ -112,6 +112,13 @@ public interface OperatorIfc {
   int getPrecedence(ExpressionConfiguration configuration);
 
   /**
+   * Checks if the operand is lazy.
+   *
+   * @return <code>true</code> if operands are defined as lazy.
+   */
+  boolean isOperandLazy();
+
+  /**
    * Performs the operator logic and returns an evaluation result.
    *
    * @param expression The expression, where this function is executed. Can be used to access the

--- a/src/main/java/com/ezylang/evalex/operators/booleans/InfixAndOperator.java
+++ b/src/main/java/com/ezylang/evalex/operators/booleans/InfixAndOperator.java
@@ -17,6 +17,7 @@ package com.ezylang.evalex.operators.booleans;
 
 import static com.ezylang.evalex.operators.OperatorIfc.OPERATOR_PRECEDENCE_AND;
 
+import com.ezylang.evalex.EvaluationException;
 import com.ezylang.evalex.Expression;
 import com.ezylang.evalex.data.EvaluationValue;
 import com.ezylang.evalex.operators.AbstractOperator;
@@ -24,12 +25,15 @@ import com.ezylang.evalex.operators.InfixOperator;
 import com.ezylang.evalex.parser.Token;
 
 /** Boolean AND of two values. */
-@InfixOperator(precedence = OPERATOR_PRECEDENCE_AND)
+@InfixOperator(precedence = OPERATOR_PRECEDENCE_AND, operandsLazy = true)
 public class InfixAndOperator extends AbstractOperator {
 
   @Override
   public EvaluationValue evaluate(
-      Expression expression, Token operatorToken, EvaluationValue... operands) {
-    return expression.convertValue(operands[0].getBooleanValue() && operands[1].getBooleanValue());
+      Expression expression, Token operatorToken, EvaluationValue... operands)
+      throws EvaluationException {
+    return expression.convertValue(
+        expression.evaluateSubtree(operands[0].getExpressionNode()).getBooleanValue()
+            && expression.evaluateSubtree(operands[1].getExpressionNode()).getBooleanValue());
   }
 }

--- a/src/main/java/com/ezylang/evalex/operators/booleans/InfixOrOperator.java
+++ b/src/main/java/com/ezylang/evalex/operators/booleans/InfixOrOperator.java
@@ -17,6 +17,7 @@ package com.ezylang.evalex.operators.booleans;
 
 import static com.ezylang.evalex.operators.OperatorIfc.OPERATOR_PRECEDENCE_OR;
 
+import com.ezylang.evalex.EvaluationException;
 import com.ezylang.evalex.Expression;
 import com.ezylang.evalex.data.EvaluationValue;
 import com.ezylang.evalex.operators.AbstractOperator;
@@ -24,12 +25,15 @@ import com.ezylang.evalex.operators.InfixOperator;
 import com.ezylang.evalex.parser.Token;
 
 /** Boolean OR of two values. */
-@InfixOperator(precedence = OPERATOR_PRECEDENCE_OR)
+@InfixOperator(precedence = OPERATOR_PRECEDENCE_OR, operandsLazy = true)
 public class InfixOrOperator extends AbstractOperator {
 
   @Override
   public EvaluationValue evaluate(
-      Expression expression, Token operatorToken, EvaluationValue... operands) {
-    return expression.convertValue(operands[0].getBooleanValue() || operands[1].getBooleanValue());
+      Expression expression, Token operatorToken, EvaluationValue... operands)
+      throws EvaluationException {
+    return expression.convertValue(
+        expression.evaluateSubtree(operands[0].getExpressionNode()).getBooleanValue()
+            || expression.evaluateSubtree(operands[1].getExpressionNode()).getBooleanValue());
   }
 }

--- a/src/test/java/com/ezylang/evalex/operators/booleans/InfixAndOperatorTest.java
+++ b/src/test/java/com/ezylang/evalex/operators/booleans/InfixAndOperatorTest.java
@@ -35,7 +35,8 @@ class InfixAndOperatorTest extends BaseEvaluationTest {
         "\"true\"&&\"false\" : false",
         "\"false\"&&\"false\" : false",
         "(1==1)&&(2==2) : true",
-        "(5>4)&&(4<6) :true"
+        "(5>4)&&(4<6) :true",
+        "false && NULL < 0 : false"
       })
   void testInfixLessLiterals(String expression, String expectedResult)
       throws EvaluationException, ParseException {

--- a/src/test/java/com/ezylang/evalex/operators/booleans/InfixOrOperatorTest.java
+++ b/src/test/java/com/ezylang/evalex/operators/booleans/InfixOrOperatorTest.java
@@ -36,7 +36,8 @@ class InfixOrOperatorTest extends BaseEvaluationTest {
         "\"true\"||\"false\" : true",
         "\"false\"||\"false\" : false",
         "(1==1)||(2==3) : true",
-        "(2>4)||(4<6) :true"
+        "(2>4)||(4<6) :true",
+        "true || NULL < 0 : true"
       })
   void testInfixLessLiterals(String expression, String expectedResult)
       throws EvaluationException, ParseException {


### PR DESCRIPTION
This implementation changes existing `&&` and `||` operators and it seems to be fine. Alternatively we can keep the existing operators unchanged but then we need to add tests for using custom operators. I can see currently all features such as `isLazy` from functionParameter are used at least once by one of the built-in operator/function so I last time I checked, I didn't find tests for implementing some features purely for the purpose of being used by custom operator/function.

This fixes: https://github.com/ezylang/EvalEx/issues/427