### PR TITLE
EvaluationValue optimization

### DIFF
--- a/src/main/java/com/ezylang/evalex/Expression.java
+++ b/src/main/java/com/ezylang/evalex/Expression.java
@@ -367,7 +367,7 @@ public class Expression {
    * @return An {@link EvaluationValue} of the detected type and value.
    */
   public EvaluationValue convertValue(Object value) {
-    return new EvaluationValue(value, configuration);
+    return EvaluationValue.of(value, configuration);
   }
 
   /**

--- a/src/main/java/com/ezylang/evalex/config/ExpressionConfiguration.java
+++ b/src/main/java/com/ezylang/evalex/config/ExpressionConfiguration.java
@@ -344,8 +344,8 @@ public class ExpressionConfiguration {
 
     Map<String, EvaluationValue> constants = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 
-    constants.put("TRUE", EvaluationValue.booleanValue(true));
-    constants.put("FALSE", EvaluationValue.booleanValue(false));
+    constants.put("TRUE", EvaluationValue.TRUE);
+    constants.put("FALSE", EvaluationValue.FALSE);
     constants.put(
         "PI",
         EvaluationValue.numberValue(

--- a/src/main/java/com/ezylang/evalex/data/EvaluationValue.java
+++ b/src/main/java/com/ezylang/evalex/data/EvaluationValue.java
@@ -38,7 +38,13 @@ import lombok.Value;
 public final class EvaluationValue implements Comparable<EvaluationValue> {
 
   /** A pre-built, immutable, null value. */
-  private static final EvaluationValue NULL_VALUE = new EvaluationValue(null, DataType.NULL);
+  public static final EvaluationValue NULL_VALUE = new EvaluationValue(null, DataType.NULL);
+
+  /** A pre-built, immutable, <code>false</code> boolean value. */
+  public static final EvaluationValue FALSE = new EvaluationValue(false, DataType.BOOLEAN);
+
+  /** A pre-built, immutable, <code>true</code> boolean value. */
+  public static final EvaluationValue TRUE = new EvaluationValue(true, DataType.BOOLEAN);
 
   /** Return value for a null {@link DataType#BOOLEAN}. */
   private static final Boolean NULL_BOOLEAN = null;
@@ -101,7 +107,9 @@ public final class EvaluationValue implements Comparable<EvaluationValue> {
    * @param configuration The expression configuration to use.
    * @throws IllegalArgumentException if the data type can't be mapped.
    * @see ExpressionConfiguration#getEvaluationValueConverter()
+   * @deprecated Use {@link EvaluationValue#of(Object, ExpressionConfiguration)} instead.
    */
+  @Deprecated(since = "3.2.0")
   public EvaluationValue(Object value, ExpressionConfiguration configuration) {
 
     EvaluationValue converted =
@@ -120,6 +128,18 @@ public final class EvaluationValue implements Comparable<EvaluationValue> {
   private EvaluationValue(Object value, DataType dataType) {
     this.dataType = dataType;
     this.value = value;
+  }
+
+  /**
+   * Creates a new evaluation value by using the configured converter and configuration.
+   *
+   * @param value One of the supported data types.
+   * @param configuration The expression configuration to use; not null
+   * @throws IllegalArgumentException if the data type can't be mapped.
+   * @see ExpressionConfiguration#getEvaluationValueConverter()
+   */
+  public static EvaluationValue of(Object value, ExpressionConfiguration configuration) {
+    return configuration.getEvaluationValueConverter().convertObject(value, configuration);
   }
 
   /**
@@ -158,7 +178,7 @@ public final class EvaluationValue implements Comparable<EvaluationValue> {
    * @return the new boolean value.
    */
   public static EvaluationValue booleanValue(Boolean value) {
-    return new EvaluationValue(value, DataType.BOOLEAN);
+    return value != null && value.booleanValue() ? TRUE : FALSE;
   }
 
   /**

--- a/src/main/java/com/ezylang/evalex/data/EvaluationValue.java
+++ b/src/main/java/com/ezylang/evalex/data/EvaluationValue.java
@@ -35,7 +35,10 @@ import lombok.Value;
  * corresponding object type.
  */
 @Value
-public class EvaluationValue implements Comparable<EvaluationValue> {
+public final class EvaluationValue implements Comparable<EvaluationValue> {
+
+  /** A pre-built, immutable, null value. */
+  private static final EvaluationValue NULL_VALUE = new EvaluationValue(null, DataType.NULL);
 
   /** Return value for a null {@link DataType#BOOLEAN}. */
   private static final Boolean NULL_BOOLEAN = null;
@@ -120,12 +123,12 @@ public class EvaluationValue implements Comparable<EvaluationValue> {
   }
 
   /**
-   * Creates a new null value.
+   * Returns a null value (immutable).
    *
-   * @return A new null value.
+   * @return A null value.
    */
   public static EvaluationValue nullValue() {
-    return new EvaluationValue(null, DataType.NULL);
+    return NULL_VALUE;
   }
 
   /**

--- a/src/main/java/com/ezylang/evalex/data/conversion/ArrayConverter.java
+++ b/src/main/java/com/ezylang/evalex/data/conversion/ArrayConverter.java
@@ -46,7 +46,7 @@ public class ArrayConverter implements ConverterIfc {
   private static List<EvaluationValue> convertList(
       List<?> object, ExpressionConfiguration configuration) {
     return object.stream()
-        .map(element -> new EvaluationValue(element, configuration))
+        .map(element -> EvaluationValue.of(element, configuration))
         .collect(Collectors.toList());
   }
 
@@ -76,7 +76,7 @@ public class ArrayConverter implements ConverterIfc {
       int[] array, ExpressionConfiguration configuration) {
     List<EvaluationValue> list = new ArrayList<>();
     for (int i : array) {
-      list.add(new EvaluationValue(i, configuration));
+      list.add(EvaluationValue.of(i, configuration));
     }
     return list;
   }
@@ -85,7 +85,7 @@ public class ArrayConverter implements ConverterIfc {
       long[] array, ExpressionConfiguration configuration) {
     List<EvaluationValue> list = new ArrayList<>();
     for (long l : array) {
-      list.add(new EvaluationValue(l, configuration));
+      list.add(EvaluationValue.of(l, configuration));
     }
     return list;
   }
@@ -94,7 +94,7 @@ public class ArrayConverter implements ConverterIfc {
       double[] array, ExpressionConfiguration configuration) {
     List<EvaluationValue> list = new ArrayList<>();
     for (double d : array) {
-      list.add(new EvaluationValue(d, configuration));
+      list.add(EvaluationValue.of(d, configuration));
     }
     return list;
   }
@@ -103,7 +103,7 @@ public class ArrayConverter implements ConverterIfc {
       float[] array, ExpressionConfiguration configuration) {
     List<EvaluationValue> list = new ArrayList<>();
     for (float f : array) {
-      list.add(new EvaluationValue(f, configuration));
+      list.add(EvaluationValue.of(f, configuration));
     }
     return list;
   }
@@ -112,7 +112,7 @@ public class ArrayConverter implements ConverterIfc {
       short[] array, ExpressionConfiguration configuration) {
     List<EvaluationValue> list = new ArrayList<>();
     for (short s : array) {
-      list.add(new EvaluationValue(s, configuration));
+      list.add(EvaluationValue.of(s, configuration));
     }
     return list;
   }
@@ -121,7 +121,7 @@ public class ArrayConverter implements ConverterIfc {
       char[] array, ExpressionConfiguration configuration) {
     List<EvaluationValue> list = new ArrayList<>();
     for (char c : array) {
-      list.add(new EvaluationValue(c, configuration));
+      list.add(EvaluationValue.of(c, configuration));
     }
     return list;
   }
@@ -130,7 +130,7 @@ public class ArrayConverter implements ConverterIfc {
       byte[] array, ExpressionConfiguration configuration) {
     List<EvaluationValue> list = new ArrayList<>();
     for (byte b : array) {
-      list.add(new EvaluationValue(b, configuration));
+      list.add(EvaluationValue.of(b, configuration));
     }
     return list;
   }
@@ -139,7 +139,7 @@ public class ArrayConverter implements ConverterIfc {
       boolean[] array, ExpressionConfiguration configuration) {
     List<EvaluationValue> list = new ArrayList<>();
     for (boolean b : array) {
-      list.add(new EvaluationValue(b, configuration));
+      list.add(EvaluationValue.of(b, configuration));
     }
     return list;
   }
@@ -148,7 +148,7 @@ public class ArrayConverter implements ConverterIfc {
       Object[] array, ExpressionConfiguration configuration) {
     List<EvaluationValue> list = new ArrayList<>();
     for (Object o : array) {
-      list.add(new EvaluationValue(o, configuration));
+      list.add(EvaluationValue.of(o, configuration));
     }
     return list;
   }

--- a/src/main/java/com/ezylang/evalex/data/conversion/StructureConverter.java
+++ b/src/main/java/com/ezylang/evalex/data/conversion/StructureConverter.java
@@ -27,7 +27,7 @@ public class StructureConverter implements ConverterIfc {
     Map<String, EvaluationValue> structure = new HashMap<>();
     for (Map.Entry<?, ?> entry : ((Map<?, ?>) object).entrySet()) {
       String name = entry.getKey().toString();
-      structure.put(name, new EvaluationValue(entry.getValue(), configuration));
+      structure.put(name, EvaluationValue.of(entry.getValue(), configuration));
     }
     return EvaluationValue.structureValue(structure);
   }

--- a/src/main/java/com/ezylang/evalex/operators/booleans/InfixEqualsOperator.java
+++ b/src/main/java/com/ezylang/evalex/operators/booleans/InfixEqualsOperator.java
@@ -31,10 +31,10 @@ public class InfixEqualsOperator extends AbstractOperator {
   public EvaluationValue evaluate(
       Expression expression, Token operatorToken, EvaluationValue... operands) {
     if (operands[0].getDataType() != operands[1].getDataType()) {
-      return EvaluationValue.booleanValue(false);
+      return EvaluationValue.FALSE;
     }
     if (operands[0].isNullValue() && operands[1].isNullValue()) {
-      return EvaluationValue.booleanValue(true);
+      return EvaluationValue.TRUE;
     }
     return expression.convertValue(operands[0].compareTo(operands[1]) == 0);
   }

--- a/src/main/java/com/ezylang/evalex/operators/booleans/InfixNotEqualsOperator.java
+++ b/src/main/java/com/ezylang/evalex/operators/booleans/InfixNotEqualsOperator.java
@@ -31,10 +31,10 @@ public class InfixNotEqualsOperator extends AbstractOperator {
   public EvaluationValue evaluate(
       Expression expression, Token operatorToken, EvaluationValue... operands) {
     if (operands[0].getDataType() != operands[1].getDataType()) {
-      return EvaluationValue.booleanValue(true);
+      return EvaluationValue.TRUE;
     }
     if (operands[0].isNullValue() && operands[1].isNullValue()) {
-      return EvaluationValue.booleanValue(false);
+      return EvaluationValue.FALSE;
     }
     return expression.convertValue(operands[0].compareTo(operands[1]) != 0);
   }

--- a/src/test/java/com/ezylang/evalex/data/EvaluationValueTest.java
+++ b/src/test/java/com/ezylang/evalex/data/EvaluationValueTest.java
@@ -531,6 +531,13 @@ class EvaluationValueTest {
   }
 
   @Test
+  void testNullValueSameInstance() {
+    EvaluationValue nullValue1 = EvaluationValue.nullValue();
+    EvaluationValue nullValue2 = EvaluationValue.nullValue();
+    assertThat(nullValue1).isSameAs(nullValue2);
+  }
+
+  @Test
   void nestedEvaluationValue() {
     try {
       EvaluationValue value1 = new EvaluationValue("Hello", defaultConfiguration());

--- a/src/test/java/com/ezylang/evalex/data/EvaluationValueTest.java
+++ b/src/test/java/com/ezylang/evalex/data/EvaluationValueTest.java
@@ -125,6 +125,16 @@ class EvaluationValueTest {
   }
 
   @Test
+  void testBooleanValueSameInstances() {
+    assertThat(EvaluationValue.booleanValue(Boolean.TRUE)).isSameAs(EvaluationValue.TRUE);
+    assertThat(EvaluationValue.booleanValue(true)).isSameAs(EvaluationValue.TRUE);
+
+    assertThat(EvaluationValue.booleanValue(Boolean.FALSE)).isSameAs(EvaluationValue.FALSE);
+    assertThat(EvaluationValue.booleanValue(false)).isSameAs(EvaluationValue.FALSE);
+    assertThat(EvaluationValue.booleanValue(null)).isSameAs(EvaluationValue.FALSE);
+  }
+
+  @Test
   void testInstant() {
     Instant instant = Instant.parse("2022-10-30T00:00:00Z");
     EvaluationValue value = new EvaluationValue(instant, defaultConfiguration());

--- a/src/test/java/com/ezylang/evalex/data/conversion/DateTimeConverterTest.java
+++ b/src/test/java/com/ezylang/evalex/data/conversion/DateTimeConverterTest.java
@@ -70,7 +70,7 @@ class DateTimeConverterTest {
   void testLocalDateDaylightSaving() {
     LocalDate localDate = LocalDate.parse("2022-10-20");
 
-    EvaluationValue converted = new EvaluationValue(localDate, cetConfiguration);
+    EvaluationValue converted = EvaluationValue.of(localDate, cetConfiguration);
 
     assertThat(converted.getDataType()).isEqualTo(EvaluationValue.DataType.DATE_TIME);
     assertThat(converted.getValue().toString()).hasToString("2022-10-19T22:00:00Z");
@@ -80,7 +80,7 @@ class DateTimeConverterTest {
   void testLocalDateNoDaylightSaving() {
     LocalDate localDate = LocalDate.parse("2022-11-20");
 
-    EvaluationValue converted = new EvaluationValue(localDate, cetConfiguration);
+    EvaluationValue converted = EvaluationValue.of(localDate, cetConfiguration);
 
     assertThat(converted.getDataType()).isEqualTo(EvaluationValue.DataType.DATE_TIME);
     assertThat(converted.getValue().toString()).hasToString("2022-11-19T23:00:00Z");
@@ -90,7 +90,7 @@ class DateTimeConverterTest {
   void testLocalDateTimeDaylightSaving() {
     LocalDateTime localDateTime = LocalDateTime.parse("2022-10-20T11:21:30");
 
-    EvaluationValue converted = new EvaluationValue(localDateTime, cetConfiguration);
+    EvaluationValue converted = EvaluationValue.of(localDateTime, cetConfiguration);
 
     assertThat(converted.getDataType()).isEqualTo(EvaluationValue.DataType.DATE_TIME);
     assertThat(converted.getValue().toString()).hasToString("2022-10-20T09:21:30Z");
@@ -100,7 +100,7 @@ class DateTimeConverterTest {
   void testLocalDateTimeNoDaylightSaving() {
     LocalDateTime localDateTime = LocalDateTime.parse("2022-11-20T11:21:30");
 
-    EvaluationValue converted = new EvaluationValue(localDateTime, cetConfiguration);
+    EvaluationValue converted = EvaluationValue.of(localDateTime, cetConfiguration);
 
     assertThat(converted.getDataType()).isEqualTo(EvaluationValue.DataType.DATE_TIME);
     assertThat(converted.getValue().toString()).hasToString("2022-11-20T10:21:30Z");


### PR DESCRIPTION
This PR optimizes the existing method `EvaluationValue.nullValue()` to return a shared, pre-built `EvaluationValue` instance (and not create a new object at each call).

Since it's an immutable object, it is safe to reuse the same instance without issues (similar to `Collections.emptyList()`, or `BigDecimal.ZERO`, for example).

By reusing the same object, we avoid GC overhead.