### PR TITLE
Remove warnings from JUnit classes

### DIFF
--- a/src/test/java/com/ezylang/evalex/ExpressionEvaluatorConstantsTest.java
+++ b/src/test/java/com/ezylang/evalex/ExpressionEvaluatorConstantsTest.java
@@ -52,12 +52,9 @@ class ExpressionEvaluatorConstantsTest extends BaseExpressionEvaluatorTest {
   @Test
   void testCustomConstantsMixedCase() throws EvaluationException, ParseException {
     Map<String, EvaluationValue> constants =
-        new HashMap<>() {
-          {
-            put("A", EvaluationValue.numberValue(new BigDecimal("2.5")));
-            put("B", EvaluationValue.numberValue(new BigDecimal("3.9")));
-          }
-        };
+        Map.of(
+            "A", EvaluationValue.numberValue(new BigDecimal("2.5")),
+            "B", EvaluationValue.numberValue(new BigDecimal("3.9")));
 
     ExpressionConfiguration configuration =
         ExpressionConfiguration.builder().defaultConstants(constants).build();

--- a/src/test/java/com/ezylang/evalex/ExpressionEvaluatorDecimalPlacesTest.java
+++ b/src/test/java/com/ezylang/evalex/ExpressionEvaluatorDecimalPlacesTest.java
@@ -21,7 +21,6 @@ import com.ezylang.evalex.config.ExpressionConfiguration;
 import com.ezylang.evalex.data.EvaluationValue;
 import com.ezylang.evalex.parser.ParseException;
 import java.math.BigDecimal;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -65,12 +64,7 @@ class ExpressionEvaluatorDecimalPlacesTest extends BaseExpressionEvaluatorTest {
 
   @Test
   void testDefaultNoRoundingStructure() throws ParseException, EvaluationException {
-    Map<String, BigDecimal> structure =
-        new HashMap<>() {
-          {
-            put("b", new BigDecimal("1.12345"));
-          }
-        };
+    Map<String, BigDecimal> structure = Map.of("b", new BigDecimal("1.12345"));
 
     Expression expression = createExpression("a.b").with("a", structure);
 
@@ -138,12 +132,7 @@ class ExpressionEvaluatorDecimalPlacesTest extends BaseExpressionEvaluatorTest {
   void testCustomRoundingStructure() throws ParseException, EvaluationException {
     ExpressionConfiguration config =
         ExpressionConfiguration.builder().decimalPlacesRounding(3).build();
-    Map<String, BigDecimal> structure =
-        new HashMap<>() {
-          {
-            put("b", new BigDecimal("1.12345"));
-          }
-        };
+    Map<String, BigDecimal> structure = Map.of("b", new BigDecimal("1.12345"));
 
     Expression expression = new Expression("a.b", config).with("a", structure);
 

--- a/src/test/java/com/ezylang/evalex/ExpressionEvaluatorStructureTest.java
+++ b/src/test/java/com/ezylang/evalex/ExpressionEvaluatorStructureTest.java
@@ -30,12 +30,7 @@ class ExpressionEvaluatorStructureTest extends BaseExpressionEvaluatorTest {
 
   @Test
   void testStructureScientificNumberDistinction() throws EvaluationException, ParseException {
-    Map<String, BigDecimal> structure =
-        new HashMap<>() {
-          {
-            put("environment_id", new BigDecimal(12345));
-          }
-        };
+    Map<String, BigDecimal> structure = Map.of("environment_id", new BigDecimal(12345));
     Expression expression = new Expression("order.environment_id").with("order", structure);
 
     assertThat(expression.evaluate().getStringValue()).isEqualTo("12345");
@@ -59,12 +54,7 @@ class ExpressionEvaluatorStructureTest extends BaseExpressionEvaluatorTest {
 
   @Test
   void testSimpleStructure() throws ParseException, EvaluationException {
-    Map<String, BigDecimal> structure =
-        new HashMap<>() {
-          {
-            put("b", new BigDecimal(99));
-          }
-        };
+    Map<String, BigDecimal> structure = Map.of("b", new BigDecimal(99));
 
     Expression expression = createExpression("a.b").with("a", structure);
 
@@ -75,12 +65,7 @@ class ExpressionEvaluatorStructureTest extends BaseExpressionEvaluatorTest {
   void testTripleStructure() throws ParseException, EvaluationException {
     Map<String, Map<String, BigDecimal>> structure = new HashMap<>();
 
-    Map<String, BigDecimal> subStructure =
-        new HashMap<>() {
-          {
-            put("c", new BigDecimal(95));
-          }
-        };
+    Map<String, BigDecimal> subStructure = Map.of("c", new BigDecimal(95));
 
     structure.put("b", subStructure);
 
@@ -133,12 +118,7 @@ class ExpressionEvaluatorStructureTest extends BaseExpressionEvaluatorTest {
 
   @Test
   void testStructureWithSpaceInNameAndArrayAccess() throws EvaluationException, ParseException {
-    Map<String, List<Integer>> structure =
-        new HashMap<>() {
-          {
-            put("b prop", Arrays.asList(1, 2, 3));
-          }
-        };
+    Map<String, List<Integer>> structure = Map.of("b prop", Arrays.asList(1, 2, 3));
 
     Expression expression = createExpression("a.\"b prop\"[1]").with("a", structure);
 

--- a/src/test/java/com/ezylang/evalex/config/ExpressionConfigurationTest.java
+++ b/src/test/java/com/ezylang/evalex/config/ExpressionConfigurationTest.java
@@ -25,7 +25,6 @@ import com.ezylang.evalex.operators.OperatorIfc;
 import com.ezylang.evalex.operators.arithmetic.InfixPlusOperator;
 import java.math.MathContext;
 import java.time.ZoneId;
-import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -135,12 +134,9 @@ class ExpressionConfigurationTest {
   @Test
   void testCustomConstants() {
     Map<String, EvaluationValue> constants =
-        new HashMap<>() {
-          {
-            put("A", EvaluationValue.stringValue("a"));
-            put("B", EvaluationValue.stringValue("b"));
-          }
-        };
+        Map.of(
+            "A", EvaluationValue.stringValue("a"),
+            "B", EvaluationValue.stringValue("b"));
     ExpressionConfiguration configuration =
         ExpressionConfiguration.builder().defaultConstants(constants).build();
 

--- a/src/test/java/com/ezylang/evalex/operators/booleans/InfixEqualsOperatorTest.java
+++ b/src/test/java/com/ezylang/evalex/operators/booleans/InfixEqualsOperatorTest.java
@@ -23,7 +23,6 @@ import com.ezylang.evalex.Expression;
 import com.ezylang.evalex.parser.ParseException;
 import java.math.BigDecimal;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -123,28 +122,19 @@ class InfixEqualsOperatorTest extends BaseEvaluationTest {
     Expression expression = new Expression("a=b");
 
     Map<String, BigDecimal> structure1 =
-        new HashMap<>() {
-          {
-            put("a", new BigDecimal(35));
-            put("b", new BigDecimal(99));
-          }
-        };
+        Map.of(
+            "a", new BigDecimal(35),
+            "b", new BigDecimal(99));
 
     Map<String, BigDecimal> structure2 =
-        new HashMap<>() {
-          {
-            put("a", new BigDecimal(35));
-            put("b", new BigDecimal(99));
-          }
-        };
+        Map.of(
+            "a", new BigDecimal(35),
+            "b", new BigDecimal(99));
 
     Map<String, BigDecimal> structure3 =
-        new HashMap<>() {
-          {
-            put("a", new BigDecimal(45));
-            put("b", new BigDecimal(99));
-          }
-        };
+        Map.of(
+            "a", new BigDecimal(45),
+            "b", new BigDecimal(99));
 
     assertThat(expression.with("a", structure1).and("b", structure2).evaluate().getBooleanValue())
         .isTrue();

--- a/src/test/java/com/ezylang/evalex/operators/booleans/InfixNotEqualsOperatorTest.java
+++ b/src/test/java/com/ezylang/evalex/operators/booleans/InfixNotEqualsOperatorTest.java
@@ -23,7 +23,6 @@ import com.ezylang.evalex.Expression;
 import com.ezylang.evalex.parser.ParseException;
 import java.math.BigDecimal;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -123,28 +122,19 @@ class InfixNotEqualsOperatorTest extends BaseEvaluationTest {
     Expression expression = new Expression("a!=b");
 
     Map<String, BigDecimal> structure1 =
-        new HashMap<>() {
-          {
-            put("a", new BigDecimal(35));
-            put("b", new BigDecimal(99));
-          }
-        };
+        Map.of(
+            "a", new BigDecimal(35),
+            "b", new BigDecimal(99));
 
     Map<String, BigDecimal> structure2 =
-        new HashMap<>() {
-          {
-            put("a", new BigDecimal(35));
-            put("b", new BigDecimal(99));
-          }
-        };
+        Map.of(
+            "a", new BigDecimal(35),
+            "b", new BigDecimal(99));
 
     Map<String, BigDecimal> structure3 =
-        new HashMap<>() {
-          {
-            put("a", new BigDecimal(45));
-            put("b", new BigDecimal(99));
-          }
-        };
+        Map.of(
+            "a", new BigDecimal(45),
+            "b", new BigDecimal(99));
 
     assertThat(expression.with("a", structure1).and("b", structure2).evaluate().getBooleanValue())
         .isFalse();


### PR DESCRIPTION
This PR removes warnings from JUnit classes that used to extend HashMap to create test maps (old-fashioned). I am replacing these occurrences with a more modern option, introduced by JDK 9: `Map.of(K, V, ...)`.