### PR TITLE
Fix custom function docs

### DIFF
--- a/docs/customization/custom_functions.md
+++ b/docs/customization/custom_functions.md
@@ -138,5 +138,5 @@ ExpressionConfiguration configuration =
             Map.entry("MAX_VALUE", new MaxFunction()),
             Map.entry("MIN_VALUE", new MinFunction()));
     
-Expression expression = new Expression("MAX_VALUE(1,2,3) + MIN_VALUE(7,8,9)");
+Expression expression = new Expression("MAX_VALUE(1,2,3) + MIN_VALUE(7,8,9)", configuration);
 ```


### PR DESCRIPTION
Currently, the code provided in the section 'Adding the Function' creates an `ExpressionConfiguration` object but doesn't use it when building the `Expression` object. This commit simply modifies the code to pass in the configuration when creating the Expression object.