### PR TITLE
Fix idea for issue #524 applying a recursion depth limiter

### DIFF
--- a/src/main/java/com/ezylang/evalex/Expression.java
+++ b/src/main/java/com/ezylang/evalex/Expression.java
@@ -31,8 +31,6 @@ import lombok.Getter;
  * @see <a href="https://github.com/ezylang/EvalEx">EvalEx Homepage</a>
  */
 public class Expression {
-  // TODO make it configurable via ExpressionConfiguration???
-  private static final int MAX_DEPTH = 2_000;
 
   @Getter private final ExpressionConfiguration configuration;
 
@@ -128,7 +126,7 @@ public class Expression {
    * @throws EvaluationException If there were problems while evaluating the expression.
    */
   private EvaluationValue evaluateSubtree(ASTNode startNode, int depth) throws EvaluationException {
-    if (depth > MAX_DEPTH) {
+    if (depth > configuration.getMaxRecursionDepth()) {
       throw new EvaluationException(startNode.getToken(), "Max recursion depth exceeded");
     }
 

--- a/src/main/java/com/ezylang/evalex/Expression.java
+++ b/src/main/java/com/ezylang/evalex/Expression.java
@@ -120,8 +120,8 @@ public class Expression {
    * Evaluates only a subtree of the abstract syntax tree.
    *
    * @param startNode The {@link ASTNode} to start evaluation from.
-   * @param depth The current depth, to track recursion level and secure it does not exceed
-   *     MAX_DEPTH
+   * @param depth The current depth, to track recursion level and secure it does not exceed the
+   *     maximum level defined by {@link ExpressionConfiguration#getMaxRecursionDepth()}
    * @return The evaluation result value.
    * @throws EvaluationException If there were problems while evaluating the expression.
    */

--- a/src/main/java/com/ezylang/evalex/Expression.java
+++ b/src/main/java/com/ezylang/evalex/Expression.java
@@ -31,6 +31,9 @@ import lombok.Getter;
  * @see <a href="https://github.com/ezylang/EvalEx">EvalEx Homepage</a>
  */
 public class Expression {
+  // TODO make it configurable via ExpressionConfiguration???
+  private static final int MAX_DEPTH = 2_000;
+
   @Getter private final ExpressionConfiguration configuration;
 
   @Getter private final String expressionString;
@@ -86,7 +89,7 @@ public class Expression {
    * @throws ParseException If there were problems while parsing the expression.
    */
   public EvaluationValue evaluate() throws EvaluationException, ParseException {
-    EvaluationValue result = evaluateSubtree(getAbstractSyntaxTree());
+    EvaluationValue result = evaluateSubtree(getAbstractSyntaxTree(), 0);
     if (result.isNumberValue()) {
       BigDecimal bigDecimal = result.getNumberValue();
       if (configuration.getDecimalPlacesResult()
@@ -112,6 +115,23 @@ public class Expression {
    * @throws EvaluationException If there were problems while evaluating the expression.
    */
   public EvaluationValue evaluateSubtree(ASTNode startNode) throws EvaluationException {
+    return evaluateSubtree(startNode, 0);
+  }
+
+  /**
+   * Evaluates only a subtree of the abstract syntax tree.
+   *
+   * @param startNode The {@link ASTNode} to start evaluation from.
+   * @param depth The current depth, to track recursion level and secure it does not exceed
+   *     MAX_DEPTH
+   * @return The evaluation result value.
+   * @throws EvaluationException If there were problems while evaluating the expression.
+   */
+  private EvaluationValue evaluateSubtree(ASTNode startNode, int depth) throws EvaluationException {
+    if (depth > MAX_DEPTH) {
+      throw new EvaluationException(startNode.getToken(), "Max recursion depth exceeded");
+    }
+
     Token token = startNode.getToken();
     EvaluationValue result;
     switch (token.getType()) {
@@ -124,7 +144,7 @@ public class Expression {
       case VARIABLE_OR_CONSTANT:
         result = getVariableOrConstant(token);
         if (result.isExpressionNode()) {
-          result = evaluateSubtree(result.getExpressionNode());
+          result = evaluateSubtree(result.getExpressionNode(), depth + 1);
         }
         break;
       case PREFIX_OPERATOR:
@@ -132,19 +152,20 @@ public class Expression {
         result =
             token
                 .getOperatorDefinition()
-                .evaluate(this, token, evaluateSubtree(startNode.getParameters().get(0)));
+                .evaluate(
+                    this, token, evaluateSubtree(startNode.getParameters().get(0), depth + 1));
         break;
       case INFIX_OPERATOR:
-        result = evaluateInfixOperator(startNode, token);
+        result = evaluateInfixOperator(startNode, token, depth + 1);
         break;
       case ARRAY_INDEX:
-        result = evaluateArrayIndex(startNode);
+        result = evaluateArrayIndex(startNode, depth + 1);
         break;
       case STRUCTURE_SEPARATOR:
-        result = evaluateStructureSeparator(startNode);
+        result = evaluateStructureSeparator(startNode, depth + 1);
         break;
       case FUNCTION:
-        result = evaluateFunction(startNode, token);
+        result = evaluateFunction(startNode, token, depth + 1);
         break;
       default:
         throw new EvaluationException(token, "Unexpected evaluation token: " + token);
@@ -171,14 +192,14 @@ public class Expression {
     return result;
   }
 
-  private EvaluationValue evaluateFunction(ASTNode startNode, Token token)
+  private EvaluationValue evaluateFunction(ASTNode startNode, Token token, int depth)
       throws EvaluationException {
     List<EvaluationValue> parameterResults = new ArrayList<>();
     for (int i = 0; i < startNode.getParameters().size(); i++) {
       if (token.getFunctionDefinition().isParameterLazy(i)) {
         parameterResults.add(convertValue(startNode.getParameters().get(i)));
       } else {
-        parameterResults.add(evaluateSubtree(startNode.getParameters().get(i)));
+        parameterResults.add(evaluateSubtree(startNode.getParameters().get(i), depth + 1));
       }
     }
 
@@ -191,9 +212,10 @@ public class Expression {
     return function.evaluate(this, token, parameters);
   }
 
-  private EvaluationValue evaluateArrayIndex(ASTNode startNode) throws EvaluationException {
-    EvaluationValue array = evaluateSubtree(startNode.getParameters().get(0));
-    EvaluationValue index = evaluateSubtree(startNode.getParameters().get(1));
+  private EvaluationValue evaluateArrayIndex(ASTNode startNode, int depth)
+      throws EvaluationException {
+    EvaluationValue array = evaluateSubtree(startNode.getParameters().get(0), depth + 1);
+    EvaluationValue index = evaluateSubtree(startNode.getParameters().get(1), depth + 1);
 
     if (array.isArrayValue() && index.isNumberValue()) {
       if (index.getNumberValue().intValue() < 0
@@ -210,8 +232,9 @@ public class Expression {
     }
   }
 
-  private EvaluationValue evaluateStructureSeparator(ASTNode startNode) throws EvaluationException {
-    EvaluationValue structure = evaluateSubtree(startNode.getParameters().get(0));
+  private EvaluationValue evaluateStructureSeparator(ASTNode startNode, int depth)
+      throws EvaluationException {
+    EvaluationValue structure = evaluateSubtree(startNode.getParameters().get(0), depth + 1);
     Token nameToken = startNode.getParameters().get(1).getToken();
     String name = nameToken.getValue();
 
@@ -226,7 +249,7 @@ public class Expression {
     }
   }
 
-  private EvaluationValue evaluateInfixOperator(ASTNode startNode, Token token)
+  private EvaluationValue evaluateInfixOperator(ASTNode startNode, Token token, int depth)
       throws EvaluationException {
     EvaluationValue left;
     EvaluationValue right;
@@ -236,8 +259,8 @@ public class Expression {
       left = convertValue(startNode.getParameters().get(0));
       right = convertValue(startNode.getParameters().get(1));
     } else {
-      left = evaluateSubtree(startNode.getParameters().get(0));
-      right = evaluateSubtree(startNode.getParameters().get(1));
+      left = evaluateSubtree(startNode.getParameters().get(0), depth + 1);
+      right = evaluateSubtree(startNode.getParameters().get(1), depth + 1);
     }
     return op.evaluate(this, token, left, right);
   }

--- a/src/main/java/com/ezylang/evalex/config/ExpressionConfiguration.java
+++ b/src/main/java/com/ezylang/evalex/config/ExpressionConfiguration.java
@@ -165,6 +165,9 @@ public class ExpressionConfiguration {
   public static final MathContext DEFAULT_MATH_CONTEXT =
       new MathContext(68, RoundingMode.HALF_EVEN);
 
+  /** The default maximum depth for recursion is 2000 levels. */
+  public static final int DEFAULT_MAX_RECURSION_DEPTH = 2_000;
+
   /**
    * The default date time formatters used when parsing a date string. Each format will be tried and
    * the first matching will be used.
@@ -375,6 +378,9 @@ public class ExpressionConfiguration {
 
   /** The locale. By default, the system default locale is used. */
   @Builder.Default private final Locale locale = Locale.getDefault();
+
+  /** The maximum recursion depth allowed for nested expressions. */
+  @Builder.Default private final int maxRecursionDepth = DEFAULT_MAX_RECURSION_DEPTH;
 
   /**
    * The date-time formatters. When parsing, each format will be tried and the first matching will

--- a/src/test/java/com/ezylang/evalex/ExpressionTest.java
+++ b/src/test/java/com/ezylang/evalex/ExpressionTest.java
@@ -218,4 +218,26 @@ class ExpressionTest {
     assertThat(expressionCopy.getDataAccessor().getData("a"))
         .isEqualTo(EvaluationValue.stringValue("2"));
   }
+
+  @Test
+  void testEvaluateStackOverflowIssue() {
+    Expression expression = new Expression(generateNestedExpression(5_000));
+    assertThatThrownBy(() -> expression.evaluate())
+        .isInstanceOf(EvaluationException.class)
+        .hasMessage("Max recursion depth exceeded");
+  }
+
+  public static String generateNestedExpression(int depth) {
+    StringBuilder sb = new StringBuilder();
+    for (int i = 1; i <= depth; i++) {
+      sb.append("(");
+      sb.append(i);
+      sb.append("+");
+    }
+    sb.append("0"); // Base case
+    for (int i = 0; i < depth; i++) {
+      sb.append(")");
+    }
+    return sb.toString();
+  }
 }

--- a/src/test/java/com/ezylang/evalex/config/ExpressionConfigurationTest.java
+++ b/src/test/java/com/ezylang/evalex/config/ExpressionConfigurationTest.java
@@ -58,6 +58,8 @@ class ExpressionConfigurationTest {
     assertThat(configuration.getZoneId()).isEqualTo(ZoneId.systemDefault());
     assertThat(configuration.getLocale()).isEqualTo(Locale.getDefault());
     assertThat(configuration.isSingleQuoteStringLiteralsAllowed()).isFalse();
+    assertThat(configuration.getMaxRecursionDepth())
+        .isEqualTo(ExpressionConfiguration.DEFAULT_MAX_RECURSION_DEPTH);
   }
 
   @Test
@@ -234,5 +236,13 @@ class ExpressionConfigurationTest {
 
     assertThat(configuration.getPowerOfPrecedence())
         .isEqualTo(OperatorIfc.OPERATOR_PRECEDENCE_POWER_HIGHER);
+  }
+
+  @Test
+  void testMaxRecursionDepth() {
+    ExpressionConfiguration configuration =
+        ExpressionConfiguration.builder().maxRecursionDepth(9).build();
+
+    assertThat(configuration.getMaxRecursionDepth()).isEqualTo(9);
   }
 }


### PR DESCRIPTION
I could reproduce the error reported by issue #524 by generating a huge expression recursively, such as
`((((((1 + (2 + (3 + (4 + ... (10000 + 0)))))))))`.

Considering the `Expression.evaluateSubtree` method, I implemented a depth limiter to prevent excessive recursion and thus avoid the StackOverflowError, replacing it with an `EvaluationException` that has a more "friendly" message.

The stack size of a JVM depends on the operating system and architecture, so the maximum recursion depth should be configurable. If you agree with the solution proposal, let me know so that I may externalize the MAX_DEPTH for configuration.