### PR TITLE
Add implicit number-function multiplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ EvalEx is a handy expression evaluator for Java, that allows to parse and evalua
 - Custom functions and operators can be added.
 - Functions can be defined with a variable number of arguments (see MIN, MAX and SUM functions).
 - Supports hexadecimal and scientific notations of numbers.
-- Supports implicit multiplication, e.g. 2x or (a+b)(a-b) or 2(x-y) which equals to (a+b)\*(a-b) or 2\*(
+- Supports implicit multiplication, e.g. 2x, 2sin(x), (a+b)(a-b) or 2(x-y) which equals to (a+b)\*(a-b) or 2\*(
   x-y)
 - Lazy evaluation of function parameters (see the IF function) and support of sub-expressions.
 - Requires minimum Java version 11.

--- a/src/main/java/com/ezylang/evalex/parser/Tokenizer.java
+++ b/src/main/java/com/ezylang/evalex/parser/Tokenizer.java
@@ -105,6 +105,7 @@ public class Tokenizer {
     return ((previousToken.getType() == BRACE_CLOSE && currentToken.getType() == BRACE_OPEN)
         || (previousToken.getType() == NUMBER_LITERAL
             && currentToken.getType() == VARIABLE_OR_CONSTANT)
+        || (previousToken.getType() == NUMBER_LITERAL && currentToken.getType() == FUNCTION)
         || (previousToken.getType() == NUMBER_LITERAL && currentToken.getType() == BRACE_OPEN));
   }
 

--- a/src/test/java/com/ezylang/evalex/parser/TokenizerImplicitMultiplicationTest.java
+++ b/src/test/java/com/ezylang/evalex/parser/TokenizerImplicitMultiplicationTest.java
@@ -70,6 +70,18 @@ class TokenizerImplicitMultiplicationTest extends BaseParserTest {
   }
 
   @Test
+  void testImplicitNumberFunction() throws ParseException {
+    assertAllTokensParsedCorrectly(
+        "2F(x)",
+        new Token(1, "2", TokenType.NUMBER_LITERAL),
+        new Token(2, "*", TokenType.INFIX_OPERATOR),
+        new Token(2, "F", TokenType.FUNCTION),
+        new Token(3, "(", TokenType.BRACE_OPEN),
+        new Token(4, "x", TokenType.VARIABLE_OR_CONSTANT),
+        new Token(5, ")", TokenType.BRACE_CLOSE));
+  }
+
+  @Test
   void testImplicitMultiplicationNotAllowed() {
     ExpressionConfiguration config =
         ExpressionConfiguration.builder().implicitMultiplicationAllowed(false).build();


### PR DESCRIPTION
As it stands, a token is only recognised as an identifier (usually a function) if it starts with a character or `_` (see [this](https://github.com/ezylang/EvalEx/blob/d6af50adf282752d5a7091d6895be1a6175a1e80/src/main/java/com/ezylang/evalex/parser/Tokenizer.java#L166-L169) and [this](https://github.com/ezylang/EvalEx/blob/d6af50adf282752d5a7091d6895be1a6175a1e80/src/main/java/com/ezylang/evalex/parser/Tokenizer.java#L582)). That allows us to add implicit multiplication, such as `2abs(x)`. This was proposed in some issues like #253 and #64, the latest of which opens up this concern:
> I am not very happy with this kind of syntax, it has the potential to open a whole new can of worms. E.g. What about `A5BSIN(2)` - is this a function named `A5BSIN` or an expression `A*5*SIN(2)` ?

`A5BSIN` should technically always be considered a function, just like `atan2(` is. This PR adds previously proposed number-to-function implicit multiplication.
