### PR TITLE
New switchable lenient mode and undefined data type

### DIFF
--- a/src/main/java/com/ezylang/evalex/Expression.java
+++ b/src/main/java/com/ezylang/evalex/Expression.java
@@ -184,6 +184,9 @@ public class Expression {
       result = getDataAccessor().getData(token.getValue());
     }
     if (result == null) {
+      if (configuration.isLenientMode()) {
+        return EvaluationValue.UNDEFINED;
+      }
       throw new EvaluationException(
           token, String.format("Variable or constant value for '%s' not found", token.getValue()));
     }

--- a/src/main/java/com/ezylang/evalex/config/ExpressionConfiguration.java
+++ b/src/main/java/com/ezylang/evalex/config/ExpressionConfiguration.java
@@ -338,6 +338,13 @@ public class ExpressionConfiguration {
   @Builder.Default private final boolean singleQuoteStringLiteralsAllowed = false;
 
   /**
+   * Allow for expressions to evaluate without errors when variables are not defined.
+   *
+   * @since 3.6.0
+   */
+  @Builder.Default private final boolean lenientMode = false;
+
+  /**
    * The power of operator precedence, can be set higher {@link
    * OperatorIfc#OPERATOR_PRECEDENCE_POWER_HIGHER} or to a custom value.
    */

--- a/src/main/java/com/ezylang/evalex/data/EvaluationValue.java
+++ b/src/main/java/com/ezylang/evalex/data/EvaluationValue.java
@@ -39,6 +39,13 @@ public class EvaluationValue implements Comparable<EvaluationValue> {
   /** A pre-built, immutable, null value. */
   public static final EvaluationValue NULL_VALUE = new EvaluationValue(null, DataType.NULL);
 
+  /**
+   * A pre-built, immutable value for an undefined variable, when the lenient mode is enabled.
+   *
+   * @since 3.6.0
+   */
+  public static final EvaluationValue UNDEFINED = new EvaluationValue(null, DataType.UNDEFINED);
+
   /** A pre-built, immutable, <code>false</code> boolean value. */
   public static final EvaluationValue FALSE = new EvaluationValue(false, DataType.BOOLEAN);
 
@@ -81,7 +88,13 @@ public class EvaluationValue implements Comparable<EvaluationValue> {
     /** A null value */
     NULL,
     /** Raw (undefined) type, stored as an {@link Object}. */
-    BINARY
+    BINARY,
+    /**
+     * Applicable for undeclared variables when lenient mode is enabled.
+     *
+     * @since 3.6.0
+     */
+    UNDEFINED;
   }
 
   Object value;
@@ -404,7 +417,7 @@ public class EvaluationValue implements Comparable<EvaluationValue> {
       case NULL:
         return NULL_BOOLEAN;
       default:
-        return false;
+        return Boolean.FALSE;
     }
   }
 

--- a/src/test/java/com/ezylang/evalex/ExpressionTest.java
+++ b/src/test/java/com/ezylang/evalex/ExpressionTest.java
@@ -240,4 +240,21 @@ class ExpressionTest {
     }
     return sb.toString();
   }
+
+  @Test
+  void testEvaluateWithUndeclaredVariablesAndDefaultMode() {
+    Expression expression = new Expression("a || b").with("a", false);
+    assertThatThrownBy(() -> expression.evaluate())
+        .isInstanceOf(EvaluationException.class)
+        .hasMessage("Variable or constant value for 'b' not found");
+  }
+
+  @Test
+  void testEvaluateWithUndeclaredVariablesAndLenientMode()
+      throws EvaluationException, ParseException {
+    Expression expression =
+        new Expression("a || b", ExpressionConfiguration.builder().lenientMode(true).build())
+            .with("a", false);
+    assertThat(expression.evaluate().getBooleanValue()).isFalse();
+  }
 }


### PR DESCRIPTION
This PR addresses the issue reported by #511 by introducing a new optional "lenient" mode which can be enabled via `ExpressionConfiguration` and allows expression to evaluate gracefully even if it contains undeclared variables.