### PR TITLE
Add JPMS module descriptor and fix Lombok/Java 11 build compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.ezylang</groupId>
     <artifactId>EvalEx</artifactId>
-    <version>3.7.0-SNAPSHOT</version>
+    <version>3.7.1-SNAPSHOT</version>
 
     <name>EvalEx</name>
 
@@ -90,6 +90,23 @@
 
     <build>
         <plugins>
+            <!-- compile with Java 11 and use Lombok annotation processor to generate code for Lombok annotations -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+                <configuration>
+                    <release>11</release>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>1.18.24</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+
             <!-- check proper code formatting using spotless -->
             <plugin>
                 <groupId>com.diffplug.spotless</groupId>
@@ -110,7 +127,7 @@
                             <include>src/test/java/**/*.java</include>
                         </includes>
                         <googleJavaFormat>
-                            <version>1.15.0</version>
+                            <version>1.24.0</version>
                             <style>GOOGLE</style>
                             <reflowLongStrings>true</reflowLongStrings>
                         </googleJavaFormat>

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,23 @@
 
     <build>
         <plugins>
+            <!-- compile with Java 11 and use Lombok annotation processor to generate code for Lombok annotations -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+                <configuration>
+                    <release>11</release>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>1.18.24</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+
             <!-- check proper code formatting using spotless -->
             <plugin>
                 <groupId>com.diffplug.spotless</groupId>
@@ -110,7 +127,7 @@
                             <include>src/test/java/**/*.java</include>
                         </includes>
                         <googleJavaFormat>
-                            <version>1.15.0</version>
+                            <version>1.24.0</version>
                             <style>GOOGLE</style>
                             <reflowLongStrings>true</reflowLongStrings>
                         </googleJavaFormat>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,32 @@
+module com.ezylang.evalex {
+  requires static lombok;
+
+  exports com.ezylang.evalex;
+  exports com.ezylang.evalex.config;
+  exports com.ezylang.evalex.data;
+  exports com.ezylang.evalex.data.conversion;
+  exports com.ezylang.evalex.functions;
+  exports com.ezylang.evalex.functions.basic;
+  exports com.ezylang.evalex.functions.datetime;
+  exports com.ezylang.evalex.functions.string;
+  exports com.ezylang.evalex.functions.trigonometric;
+  exports com.ezylang.evalex.operators;
+  exports com.ezylang.evalex.operators.arithmetic;
+  exports com.ezylang.evalex.operators.booleans;
+  exports com.ezylang.evalex.parser;
+
+  // Tests + Frameworks
+  opens com.ezylang.evalex;
+  opens com.ezylang.evalex.config;
+  opens com.ezylang.evalex.data;
+  opens com.ezylang.evalex.data.conversion;
+  opens com.ezylang.evalex.functions;
+  opens com.ezylang.evalex.functions.basic;
+  opens com.ezylang.evalex.functions.datetime;
+  opens com.ezylang.evalex.functions.string;
+  opens com.ezylang.evalex.functions.trigonometric;
+  opens com.ezylang.evalex.operators;
+  opens com.ezylang.evalex.operators.arithmetic;
+  opens com.ezylang.evalex.operators.booleans;
+  opens com.ezylang.evalex.parser;
+}

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -9,13 +9,16 @@ module com.ezylang.evalex {
   exports com.ezylang.evalex.functions.basic;
   exports com.ezylang.evalex.functions.datetime;
   exports com.ezylang.evalex.functions.string;
+  exports com.ezylang.evalex.functions.string.util;
   exports com.ezylang.evalex.functions.trigonometric;
   exports com.ezylang.evalex.operators;
   exports com.ezylang.evalex.operators.arithmetic;
   exports com.ezylang.evalex.operators.booleans;
   exports com.ezylang.evalex.parser;
 
-  // Tests + Frameworks
+  // Temporary compatibility measure:
+  // keep packages open for reflective frameworks and tests.
+  // Can be restricted in a follow-up once reflective use is narrowed down.
   opens com.ezylang.evalex;
   opens com.ezylang.evalex.config;
   opens com.ezylang.evalex.data;
@@ -24,6 +27,7 @@ module com.ezylang.evalex {
   opens com.ezylang.evalex.functions.basic;
   opens com.ezylang.evalex.functions.datetime;
   opens com.ezylang.evalex.functions.string;
+  opens com.ezylang.evalex.functions.string.util;
   opens com.ezylang.evalex.functions.trigonometric;
   opens com.ezylang.evalex.operators;
   opens com.ezylang.evalex.operators.arithmetic;


### PR DESCRIPTION
- Added `module-info.java` with module `com.ezylang.evalex`
  - Added `requires static lombok` for compile-time Lombok usage
  - Exported the library’s public API packages, including `com.ezylang.evalex.functions.string.util`
  - Opened packages for reflective access as a temporary compatibility measure (tests/frameworks)

- Fixed Lombok compilation on Java 11 by explicitly configuring annotation processing via `maven-compiler-plugin`

- Updated the Spotless `googleJavaFormat` version to `1.24.0` (the Spotless Maven plugin version itself is unchanged)

The broad `opens` directives are currently kept for compatibility and can be narrowed in a follow-up once reflective usage is reduced.