### PR TITLE
Fix CWE-400: Add upper limit to FACT function to prevent DoS attacks

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -24,6 +24,7 @@ ExpressionConfiguration configuration=ExpressionConfiguration.builder()
         .lenientMode(false)
         .locale(Locale.getDefault())
         .mathContext(ExpressionConfiguration.DEFAULT_MATH_CONTEXT)
+        .maxRecursionDepth(2000)
         .operatorDictionary(ExpressionConfiguration.StandardOperatorsDictionary)
         .powerOfPrecedence(OperatorIfc.OPERATOR_PRECEDENCE_POWER)
         .stripTrailingZeros(true)
@@ -145,6 +146,12 @@ The math context is used throughout all operations and functions. The default ha
 and a rounding mode of _HALF_EVEN_.
 
 See chapter [Precision, Scale and Rounding](../concepts/rounding.html) for details.
+
+### Maximum Recursion Depth[^2]
+
+Specifies the maximum number of nested call frames allowed during recursive operations (such as resolving
+nested expressions or calculating factorials). This parameter protects the system against stack overflow
+errors, CPU exhaustion, and Denial of Service (DoS) attacks. The default value is 2000.
 
 ### Operator Dictionary
 

--- a/src/main/java/com/ezylang/evalex/functions/basic/FactFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/basic/FactFunction.java
@@ -28,12 +28,11 @@ import java.math.BigDecimal;
 public class FactFunction extends AbstractFunction {
 
   /**
-   * Maximum allowed input value for factorial calculation.
-   * Set to 170 to align with industry-standard limits in Windows Calculator, macOS Calculator,
-   * Microsoft Excel, Google Sheets, and LibreOffice Calc.
-   * This prevents uncontrolled resource consumption (CWE-400) while maintaining compatibility
-   * with user expectations from widely-used tools.
-   * See: https://github.com/ezylang/EvalEx/issues/570
+   * Maximum allowed input value for factorial calculation, aligned with industry-standard upper
+   * limits. This prevents uncontrolled resource consumption (CWE-400) while maintaining
+   * compatibility with user expectations from widely-used tools.
+   *
+   * @see https://github.com/ezylang/EvalEx/issues/570
    */
   private static final int MAX_FACTORIAL_INPUT = 170;
 
@@ -45,8 +44,7 @@ public class FactFunction extends AbstractFunction {
 
     // Validate input to prevent uncontrolled resource consumption
     if (number < 0) {
-      throw new EvaluationException(
-          functionToken, "Factorial is not defined for negative numbers");
+      throw new EvaluationException(functionToken, "Factorial is not defined for negative numbers");
     }
 
     if (number > MAX_FACTORIAL_INPUT) {

--- a/src/main/java/com/ezylang/evalex/functions/basic/FactFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/basic/FactFunction.java
@@ -27,27 +27,19 @@ import java.math.BigDecimal;
 @FunctionParameter(name = "base")
 public class FactFunction extends AbstractFunction {
 
-  /**
-   * Maximum allowed input value for factorial calculation, aligned with industry-standard upper
-   * limits. This prevents uncontrolled resource consumption (CWE-400) while maintaining
-   * compatibility with user expectations from widely-used tools.
-   *
-   * @see https://github.com/ezylang/EvalEx/issues/570
-   */
-  private static final int MAX_FACTORIAL_INPUT = 170;
-
   @Override
   public EvaluationValue evaluate(
       Expression expression, Token functionToken, EvaluationValue... parameterValues)
       throws EvaluationException {
     int number = parameterValues[0].getNumberValue().intValue();
 
-    if (number > MAX_FACTORIAL_INPUT) {
+    int maxRecursionDepth = expression.getConfiguration().getMaxRecursionDepth();
+    if (number > maxRecursionDepth) {
       throw new EvaluationException(
           functionToken,
           String.format(
-              "Factorial input exceeds maximum allowed value: %d > %d",
-              number, MAX_FACTORIAL_INPUT));
+              "The required number exceeds the configured 'maxRecursionDepth' (value: %s)",
+              maxRecursionDepth));
     }
 
     BigDecimal factorial = BigDecimal.ONE;

--- a/src/main/java/com/ezylang/evalex/functions/basic/FactFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/basic/FactFunction.java
@@ -42,11 +42,6 @@ public class FactFunction extends AbstractFunction {
       throws EvaluationException {
     int number = parameterValues[0].getNumberValue().intValue();
 
-    // Validate input to prevent uncontrolled resource consumption
-    if (number < 0) {
-      throw new EvaluationException(functionToken, "Factorial is not defined for negative numbers");
-    }
-
     if (number > MAX_FACTORIAL_INPUT) {
       throw new EvaluationException(
           functionToken,

--- a/src/main/java/com/ezylang/evalex/functions/basic/FactFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/basic/FactFunction.java
@@ -15,6 +15,7 @@
 */
 package com.ezylang.evalex.functions.basic;
 
+import com.ezylang.evalex.EvaluationException;
 import com.ezylang.evalex.Expression;
 import com.ezylang.evalex.data.EvaluationValue;
 import com.ezylang.evalex.functions.AbstractFunction;
@@ -26,10 +27,36 @@ import java.math.BigDecimal;
 @FunctionParameter(name = "base")
 public class FactFunction extends AbstractFunction {
 
+  /**
+   * Maximum allowed input value for factorial calculation.
+   * Set to 170 to align with industry-standard limits in Windows Calculator, macOS Calculator,
+   * Microsoft Excel, Google Sheets, and LibreOffice Calc.
+   * This prevents uncontrolled resource consumption (CWE-400) while maintaining compatibility
+   * with user expectations from widely-used tools.
+   * See: https://github.com/ezylang/EvalEx/issues/570
+   */
+  private static final int MAX_FACTORIAL_INPUT = 170;
+
   @Override
   public EvaluationValue evaluate(
-      Expression expression, Token functionToken, EvaluationValue... parameterValues) {
+      Expression expression, Token functionToken, EvaluationValue... parameterValues)
+      throws EvaluationException {
     int number = parameterValues[0].getNumberValue().intValue();
+
+    // Validate input to prevent uncontrolled resource consumption
+    if (number < 0) {
+      throw new EvaluationException(
+          functionToken, "Factorial is not defined for negative numbers");
+    }
+
+    if (number > MAX_FACTORIAL_INPUT) {
+      throw new EvaluationException(
+          functionToken,
+          String.format(
+              "Factorial input exceeds maximum allowed value: %d > %d",
+              number, MAX_FACTORIAL_INPUT));
+    }
+
     BigDecimal factorial = BigDecimal.ONE;
     for (int i = 1; i <= number; i++) {
       factorial =

--- a/src/test/java/com/ezylang/evalex/functions/basic/BasicFunctionsTest.java
+++ b/src/test/java/com/ezylang/evalex/functions/basic/BasicFunctionsTest.java
@@ -57,19 +57,19 @@ class BasicFunctionsTest extends BaseEvaluationTest {
 
   @Test
   void testFactorialAtMaximumLimit() throws EvaluationException, ParseException {
-    // Test boundary condition: FACT(170) should work
-    new Expression("FACT(170)").evaluate();
+    // Test boundary condition: FACT(2000) should work
+    new Expression("FACT(2000)").evaluate();
   }
 
   @ParameterizedTest
-  @ValueSource(ints = {171, 1000, 999999})
+  @ValueSource(ints = {2001, 999999})
   void testFactorialExceedsLimit(int value) {
     String expression = String.format("FACT(%d)", value);
-    // Test that values > 170 are rejected to prevent DoS (issue #570)
+    // Test that values > 2000 (initial value for maxRecursionDepth) are rejected to prevent DoS
     assertThatThrownBy(() -> new Expression(expression).evaluate())
         .isInstanceOf(EvaluationException.class)
-        .hasMessageContaining("exceeds maximum allowed value")
-        .hasMessageContaining("170");
+        .hasMessageContaining(
+            "The required number exceeds the configured 'maxRecursionDepth' (value: 2000)");
   }
 
   @ParameterizedTest

--- a/src/test/java/com/ezylang/evalex/functions/basic/BasicFunctionsTest.java
+++ b/src/test/java/com/ezylang/evalex/functions/basic/BasicFunctionsTest.java
@@ -33,6 +33,7 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 
 class BasicFunctionsTest extends BaseEvaluationTest {
@@ -52,6 +53,23 @@ class BasicFunctionsTest extends BaseEvaluationTest {
   void testFactorial(String expression, String expectedResult)
       throws EvaluationException, ParseException {
     assertExpressionHasExpectedResult(expression, expectedResult);
+  }
+
+  @Test
+  void testFactorialAtMaximumLimit() throws EvaluationException, ParseException {
+    // Test boundary condition: FACT(170) should work
+    new Expression("FACT(170)").evaluate();
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {171, 1000, 999999})
+  void testFactorialExceedsLimit(int value) {
+    String expression = String.format("FACT(%d)", value);
+    // Test that values > 170 are rejected to prevent DoS (issue #570)
+    assertThatThrownBy(() -> new Expression(expression).evaluate())
+        .isInstanceOf(EvaluationException.class)
+        .hasMessageContaining("exceeds maximum allowed value")
+        .hasMessageContaining("170");
   }
 
   @ParameterizedTest


### PR DESCRIPTION
This commit addresses the security vulnerability reported in issue #570 by implementing a maximum input limit for the FACT function, defined by the existing configuration property 'maxRecursionDepth' (initial/default value: 2000)

Fixes #570