### PR TITLE
Fix CWE-1333: Add timeout to STR_MATCHES to prevent ReDoS attacks

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -26,6 +26,7 @@ ExpressionConfiguration configuration=ExpressionConfiguration.builder()
         .mathContext(ExpressionConfiguration.DEFAULT_MATH_CONTEXT)
         .operatorDictionary(ExpressionConfiguration.StandardOperatorsDictionary)
         .powerOfPrecedence(OperatorIfc.OPERATOR_PRECEDENCE_POWER)
+        .regexTimeoutMillis(100)
         .stripTrailingZeros(true)
         .structuresAllowed(true)
         .binaryAllowed(false)
@@ -175,6 +176,12 @@ ExpressionConfiguration configuration=ExpressionConfiguration.builder()
 // will now result in -4, instead of 4:
         Expression expression=new Expression("-2^2",configuration);
 ```
+
+### RegEx Timeout in Milliseconds
+
+Defines the maximum execution time allowed for a single regular expression matching operation.
+This parameter serves as a critical security boundary to stop Catastrophic Backtracking, which can
+freeze the CPU and lead to Denial of Service (DoS) attacks. The default value is 100 milliseconds.
 
 ### Single Quote String Literals
 

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -177,11 +177,13 @@ ExpressionConfiguration configuration=ExpressionConfiguration.builder()
         Expression expression=new Expression("-2^2",configuration);
 ```
 
-### RegEx Timeout in Milliseconds
+### RegEx Timeout in Milliseconds[^4]
 
 Defines the maximum execution time allowed for a single regular expression matching operation.
 This parameter serves as a critical security boundary to stop Catastrophic Backtracking, which can
 freeze the CPU and lead to Denial of Service (DoS) attacks. The default value is 100 milliseconds.
+
+[^4]: Since 3.6.3
 
 ### Single Quote String Literals
 

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -187,8 +187,12 @@ ExpressionConfiguration configuration=ExpressionConfiguration.builder()
 ### RegEx Timeout in Milliseconds[^4]
 
 Defines the maximum execution time allowed for a single regular expression matching operation.
-This parameter serves as a critical security boundary to stop Catastrophic Backtracking, which can
-freeze the CPU and lead to Denial of Service (DoS) attacks. The default value is 100 milliseconds.
+
+This parameter serves as a critical operational security breaker to bound Catastrophic Backtracking,
+which can otherwise consume excessive CPU resources and lead to Denial of Service (DoS) attacks.
+
+Setting this value to 0 or any negative number disables the timeout enforcement completely, allowing
+regular expression evaluations to run without any time constraints. The default value is 100 milliseconds.
 
 [^4]: Since 3.6.3
 

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -186,10 +186,8 @@ ExpressionConfiguration configuration=ExpressionConfiguration.builder()
 
 ### RegEx Timeout in Milliseconds[^4]
 
-Defines the maximum execution time allowed for a single regular expression matching operation.
-
-This parameter serves as a critical operational security breaker to bound Catastrophic Backtracking,
-which can otherwise consume excessive CPU resources and lead to Denial of Service (DoS) attacks.
+This parameter limits the maximum runtime of a single regular expression matching operation, helping to
+mitigate ReDoS risks caused by catastrophic backtracking.
 
 Setting this value to 0 or any negative number disables the timeout enforcement completely, allowing
 regular expression evaluations to run without any time constraints. The default value is 100 milliseconds.

--- a/src/main/java/com/ezylang/evalex/config/ExpressionConfiguration.java
+++ b/src/main/java/com/ezylang/evalex/config/ExpressionConfiguration.java
@@ -168,6 +168,9 @@ public class ExpressionConfiguration {
   /** The default maximum depth for recursion is 2000 levels. */
   public static final int DEFAULT_MAX_RECURSION_DEPTH = 2_000;
 
+  /** The default RegEx timeout is 100 milliseconds. */
+  public static final long DEFAULT_REGEX_TIMEOUT_MILLIS = 100L;
+
   /**
    * The default date time formatters used when parsing a date string. Each format will be tried and
    * the first matching will be used.
@@ -388,6 +391,12 @@ public class ExpressionConfiguration {
 
   /** The maximum recursion depth allowed for nested expressions. */
   @Builder.Default private final int maxRecursionDepth = DEFAULT_MAX_RECURSION_DEPTH;
+
+  /**
+   * Timeout in milliseconds for RegEx matching execution. Prevents catastrophic backtracking in
+   * RegEx patterns from consuming excessive CPU resources.
+   */
+  @Builder.Default private final long regexTimeoutMillis = DEFAULT_REGEX_TIMEOUT_MILLIS;
 
   /**
    * The date-time formatters. When parsing, each format will be tried and the first matching will

--- a/src/main/java/com/ezylang/evalex/config/ExpressionConfiguration.java
+++ b/src/main/java/com/ezylang/evalex/config/ExpressionConfiguration.java
@@ -393,8 +393,16 @@ public class ExpressionConfiguration {
   @Builder.Default private final int maxRecursionDepth = DEFAULT_MAX_RECURSION_DEPTH;
 
   /**
-   * Timeout in milliseconds for RegEx matching execution. Prevents catastrophic backtracking in
-   * RegEx patterns from consuming excessive CPU resources.
+   * The maximum execution time allowed for a single regular expression matching operation.
+   *
+   * <p>This parameter serves as a critical operational security breaker to bound Catastrophic
+   * Backtracking, which can otherwise consume excessive CPU resources and lead to Denial of Service
+   * (DoS) attacks.
+   *
+   * <p>Setting this value to 0 or any negative number disables the timeout enforcement completely,
+   * allowing regular expression evaluations to run without any time constraints.
+   *
+   * @since 3.6.3
    */
   @Builder.Default private final int regexTimeoutMillis = DEFAULT_REGEX_TIMEOUT_MILLIS;
 

--- a/src/main/java/com/ezylang/evalex/config/ExpressionConfiguration.java
+++ b/src/main/java/com/ezylang/evalex/config/ExpressionConfiguration.java
@@ -169,7 +169,7 @@ public class ExpressionConfiguration {
   public static final int DEFAULT_MAX_RECURSION_DEPTH = 2_000;
 
   /** The default RegEx timeout is 100 milliseconds. */
-  public static final long DEFAULT_REGEX_TIMEOUT_MILLIS = 100L;
+  public static final int DEFAULT_REGEX_TIMEOUT_MILLIS = 100;
 
   /**
    * The default date time formatters used when parsing a date string. Each format will be tried and
@@ -396,7 +396,7 @@ public class ExpressionConfiguration {
    * Timeout in milliseconds for RegEx matching execution. Prevents catastrophic backtracking in
    * RegEx patterns from consuming excessive CPU resources.
    */
-  @Builder.Default private final long regexTimeoutMillis = DEFAULT_REGEX_TIMEOUT_MILLIS;
+  @Builder.Default private final int regexTimeoutMillis = DEFAULT_REGEX_TIMEOUT_MILLIS;
 
   /**
    * The date-time formatters. When parsing, each format will be tried and the first matching will

--- a/src/main/java/com/ezylang/evalex/config/ExpressionConfiguration.java
+++ b/src/main/java/com/ezylang/evalex/config/ExpressionConfiguration.java
@@ -393,11 +393,8 @@ public class ExpressionConfiguration {
   @Builder.Default private final int maxRecursionDepth = DEFAULT_MAX_RECURSION_DEPTH;
 
   /**
-   * The maximum execution time allowed for a single regular expression matching operation.
-   *
-   * <p>This parameter serves as a critical operational security breaker to bound Catastrophic
-   * Backtracking, which can otherwise consume excessive CPU resources and lead to Denial of Service
-   * (DoS) attacks.
+   * This parameter limits the maximum runtime of a single regular expression matching operation,
+   * helping to mitigate ReDoS risks caused by catastrophic backtracking.
    *
    * <p>Setting this value to 0 or any negative number disables the timeout enforcement completely,
    * allowing regular expression evaluations to run without any time constraints.

--- a/src/main/java/com/ezylang/evalex/functions/string/StringMatchesFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/string/StringMatchesFunction.java
@@ -21,21 +21,101 @@ import com.ezylang.evalex.data.EvaluationValue;
 import com.ezylang.evalex.functions.AbstractFunction;
 import com.ezylang.evalex.functions.FunctionParameter;
 import com.ezylang.evalex.parser.Token;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.regex.Pattern;
 
 /**
  * Returns true if the string matches the pattern.
  *
+ * <p><strong>Security:</strong> This function is protected against ReDoS (Regular Expression
+ * Denial of Service) attacks through multiple layers of validation:
+ *
+ * <ul>
+ *   <li><strong>Pattern length limit:</strong> Maximum 100 characters to prevent overly complex
+ *       patterns
+ *   <li><strong>Dangerous construct detection:</strong> Blocks known ReDoS patterns like (a+)+,
+ *       (a*)*, etc.
+ *   <li><strong>Regex execution timeout:</strong> 100ms timeout to catch unexpected patterns
+ * </ul>
+ *
  * @author HSGamer
+ * @see <a href="https://github.com/ezylang/EvalEx/issues/570">Issue #570 - CWE-1333 ReDoS
+ *     Vulnerability</a>
  */
 @FunctionParameter(name = "string")
 @FunctionParameter(name = "pattern")
 public class StringMatchesFunction extends AbstractFunction {
+
+  /**
+   * Maximum allowed regex pattern length. Prevents excessively complex patterns that could cause
+   * performance issues or ReDoS attacks.
+   */
+  private static final int MAX_PATTERN_LENGTH = 100;
+
+  /**
+   * Timeout in milliseconds for regex matching execution. Prevents catastrophic backtracking in
+   * regex patterns from consuming excessive CPU resources.
+   */
+  private static final long REGEX_TIMEOUT_MS = 100;
+
+  /**
+   * Pattern to detect common ReDoS attack vectors. Matches nested quantifiers like (a+)+, (a*)*,
+   * etc.
+   */
+  private static final Pattern REDOS_PATTERN =
+      Pattern.compile("(\\([^)]*[+*][^)]*\\)[+*])|(\\[[^\\]]*\\][+*])");
+
+  /**
+   * Thread pool executor for executing regex matching with timeout. Shared across all invocations
+   * to avoid excessive thread creation.
+   */
+  private static final ExecutorService EXECUTOR = Executors.newFixedThreadPool(2);
+
   @Override
   public EvaluationValue evaluate(
       Expression expression, Token functionToken, EvaluationValue... parameterValues)
       throws EvaluationException {
     String string = parameterValues[0].getStringValue();
     String pattern = parameterValues[1].getStringValue();
-    return expression.convertValue(string.matches(pattern));
+
+    // Layer 1: Validate pattern length to prevent overly complex patterns
+    if (pattern.length() > MAX_PATTERN_LENGTH) {
+      throw new EvaluationException(
+          functionToken,
+          String.format(
+              "Regex pattern exceeds maximum length: %d > %d",
+              pattern.length(), MAX_PATTERN_LENGTH));
+    }
+
+    // Layer 2: Detect and reject known ReDoS patterns
+    if (REDOS_PATTERN.matcher(pattern).find()) {
+      throw new EvaluationException(
+          functionToken,
+          "Regex pattern contains potentially dangerous constructs that could cause ReDoS");
+    }
+
+    // Layer 3: Execute regex matching with timeout to catch unexpected ReDoS patterns
+    try {
+      Future<Boolean> future = EXECUTOR.submit(() -> string.matches(pattern));
+      return expression.convertValue(future.get(REGEX_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    } catch (TimeoutException e) {
+      throw new EvaluationException(
+          functionToken,
+          "Regex matching timed out - pattern may be vulnerable to ReDoS attack");
+    } catch (EvaluationException e) {
+      // Re-throw EvaluationException as-is
+      throw e;
+    } catch (Exception e) {
+      // Catch all other exceptions (InterruptedException, ExecutionException, etc.)
+      if (e.getCause() instanceof java.util.regex.PatternSyntaxException) {
+        throw new EvaluationException(
+            functionToken, "Invalid regex pattern: " + e.getCause().getMessage());
+      }
+      throw new EvaluationException(functionToken, "Regex matching failed: " + e.getMessage());
+    }
   }
 }

--- a/src/main/java/com/ezylang/evalex/functions/string/StringMatchesFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/string/StringMatchesFunction.java
@@ -21,12 +21,12 @@ import com.ezylang.evalex.data.EvaluationValue;
 import com.ezylang.evalex.functions.AbstractFunction;
 import com.ezylang.evalex.functions.FunctionParameter;
 import com.ezylang.evalex.parser.Token;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.regex.PatternSyntaxException;
 
 /**
  * Returns true if the string matches the pattern.
@@ -34,7 +34,6 @@ import java.util.regex.PatternSyntaxException;
  * <p><strong>Security:</strong> Since 3.6.3, this function applies a execution timeout defined by
  * configuration property 'regexTimeoutMillis' to prevent ReDoS (Regular Expression Denial of
  * Service).
- * </ul>
  *
  * @author HSGamer
  * @see <a href="https://github.com/ezylang/EvalEx/issues/570">Issue #570 - CWE-1333 ReDoS
@@ -64,13 +63,12 @@ public class StringMatchesFunction extends AbstractFunction {
       return expression.convertValue(future.get(regexTimeoutMillis, TimeUnit.MILLISECONDS));
     } catch (TimeoutException e) {
       throw new EvaluationException(functionToken, "Regex matching timed out");
-    } catch (Exception e) {
-      // Catch all other exceptions (InterruptedException, ExecutionException, etc.)
-      if (e.getCause() instanceof PatternSyntaxException) {
-        throw new EvaluationException(
-            functionToken, "Invalid regex pattern: " + e.getCause().getMessage());
-      }
-      throw new EvaluationException(functionToken, "Regex matching failed: " + e.getMessage());
+    } catch (ExecutionException e) {
+      throw new EvaluationException(
+          functionToken, "Invalid regex pattern: " + e.getCause().getMessage());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new EvaluationException(functionToken, "Interrupted while matching");
     }
   }
 }

--- a/src/main/java/com/ezylang/evalex/functions/string/StringMatchesFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/string/StringMatchesFunction.java
@@ -26,20 +26,14 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 /**
  * Returns true if the string matches the pattern.
  *
- * <p><strong>Security:</strong> This function is protected against ReDoS (Regular Expression
- * Denial of Service) attacks through multiple layers of validation:
- *
- * <ul>
- *   <li><strong>Pattern length limit:</strong> Maximum 100 characters to prevent overly complex
- *       patterns
- *   <li><strong>Dangerous construct detection:</strong> Blocks known ReDoS patterns like (a+)+,
- *       (a*)*, etc.
- *   <li><strong>Regex execution timeout:</strong> 100ms timeout to catch unexpected patterns
+ * <p><strong>Security:</strong> Since 3.6.3, this function applies a execution timeout defined by
+ * configuration property 'regexTimeoutMillis' to prevent ReDoS (Regular Expression Denial of
+ * Service).
  * </ul>
  *
  * @author HSGamer
@@ -51,29 +45,10 @@ import java.util.regex.Pattern;
 public class StringMatchesFunction extends AbstractFunction {
 
   /**
-   * Maximum allowed regex pattern length. Prevents excessively complex patterns that could cause
-   * performance issues or ReDoS attacks.
-   */
-  private static final int MAX_PATTERN_LENGTH = 100;
-
-  /**
-   * Timeout in milliseconds for regex matching execution. Prevents catastrophic backtracking in
-   * regex patterns from consuming excessive CPU resources.
-   */
-  private static final long REGEX_TIMEOUT_MS = 100;
-
-  /**
-   * Pattern to detect common ReDoS attack vectors. Matches nested quantifiers like (a+)+, (a*)*,
-   * etc.
-   */
-  private static final Pattern REDOS_PATTERN =
-      Pattern.compile("(\\([^)]*[+*][^)]*\\)[+*])|(\\[[^\\]]*\\][+*])");
-
-  /**
    * Thread pool executor for executing regex matching with timeout. Shared across all invocations
    * to avoid excessive thread creation.
    */
-  private static final ExecutorService EXECUTOR = Executors.newFixedThreadPool(2);
+  private static final ExecutorService EXECUTOR = Executors.newFixedThreadPool(10);
 
   @Override
   public EvaluationValue evaluate(
@@ -82,36 +57,16 @@ public class StringMatchesFunction extends AbstractFunction {
     String string = parameterValues[0].getStringValue();
     String pattern = parameterValues[1].getStringValue();
 
-    // Layer 1: Validate pattern length to prevent overly complex patterns
-    if (pattern.length() > MAX_PATTERN_LENGTH) {
-      throw new EvaluationException(
-          functionToken,
-          String.format(
-              "Regex pattern exceeds maximum length: %d > %d",
-              pattern.length(), MAX_PATTERN_LENGTH));
-    }
-
-    // Layer 2: Detect and reject known ReDoS patterns
-    if (REDOS_PATTERN.matcher(pattern).find()) {
-      throw new EvaluationException(
-          functionToken,
-          "Regex pattern contains potentially dangerous constructs that could cause ReDoS");
-    }
-
-    // Layer 3: Execute regex matching with timeout to catch unexpected ReDoS patterns
+    // Execute regex matching with timeout to catch unexpected ReDoS patterns
+    long regexTimeoutMillis = expression.getConfiguration().getRegexTimeoutMillis();
     try {
       Future<Boolean> future = EXECUTOR.submit(() -> string.matches(pattern));
-      return expression.convertValue(future.get(REGEX_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+      return expression.convertValue(future.get(regexTimeoutMillis, TimeUnit.MILLISECONDS));
     } catch (TimeoutException e) {
-      throw new EvaluationException(
-          functionToken,
-          "Regex matching timed out - pattern may be vulnerable to ReDoS attack");
-    } catch (EvaluationException e) {
-      // Re-throw EvaluationException as-is
-      throw e;
+      throw new EvaluationException(functionToken, "Regex matching timed out");
     } catch (Exception e) {
       // Catch all other exceptions (InterruptedException, ExecutionException, etc.)
-      if (e.getCause() instanceof java.util.regex.PatternSyntaxException) {
+      if (e.getCause() instanceof PatternSyntaxException) {
         throw new EvaluationException(
             functionToken, "Invalid regex pattern: " + e.getCause().getMessage());
       }

--- a/src/main/java/com/ezylang/evalex/functions/string/StringMatchesFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/string/StringMatchesFunction.java
@@ -17,16 +17,13 @@ package com.ezylang.evalex.functions.string;
 
 import com.ezylang.evalex.EvaluationException;
 import com.ezylang.evalex.Expression;
+import com.ezylang.evalex.config.ExpressionConfiguration;
 import com.ezylang.evalex.data.EvaluationValue;
 import com.ezylang.evalex.functions.AbstractFunction;
 import com.ezylang.evalex.functions.FunctionParameter;
+import com.ezylang.evalex.functions.string.util.RegularExpressionUtils;
 import com.ezylang.evalex.parser.Token;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
+import java.util.regex.Matcher;
 
 /**
  * Returns true if the string matches the pattern.
@@ -35,20 +32,12 @@ import java.util.concurrent.TimeoutException;
  * configuration property 'regexTimeoutMillis' to prevent ReDoS (Regular Expression Denial of
  * Service).
  *
+ * @see ExpressionConfiguration#getRegexTimeoutMillis()
  * @author HSGamer
- * @see <a href="https://github.com/ezylang/EvalEx/issues/570">Issue #570 - CWE-1333 ReDoS
- *     Vulnerability</a>
  */
 @FunctionParameter(name = "string")
 @FunctionParameter(name = "pattern")
 public class StringMatchesFunction extends AbstractFunction {
-
-  /**
-   * Thread pool executor for executing regex matching with timeout. Shared across all invocations
-   * to avoid excessive thread creation.
-   */
-  private static final ExecutorService EXECUTOR = Executors.newFixedThreadPool(10);
-
   @Override
   public EvaluationValue evaluate(
       Expression expression, Token functionToken, EvaluationValue... parameterValues)
@@ -56,19 +45,13 @@ public class StringMatchesFunction extends AbstractFunction {
     String string = parameterValues[0].getStringValue();
     String pattern = parameterValues[1].getStringValue();
 
-    // Execute regex matching with timeout to catch unexpected ReDoS patterns
-    long regexTimeoutMillis = expression.getConfiguration().getRegexTimeoutMillis();
+    int timeout = expression.getConfiguration().getRegexTimeoutMillis();
+    Matcher safeMatcher = RegularExpressionUtils.createMatcherWithTimeout(string, pattern, timeout);
+
     try {
-      Future<Boolean> future = EXECUTOR.submit(() -> string.matches(pattern));
-      return expression.convertValue(future.get(regexTimeoutMillis, TimeUnit.MILLISECONDS));
-    } catch (TimeoutException e) {
-      throw new EvaluationException(functionToken, "Regex matching timed out");
-    } catch (ExecutionException e) {
-      throw new EvaluationException(
-          functionToken, "Invalid regex pattern: " + e.getCause().getMessage());
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-      throw new EvaluationException(functionToken, "Interrupted while matching");
+      return expression.convertValue(safeMatcher.matches());
+    } catch (IllegalStateException e) {
+      throw new EvaluationException(functionToken, e.getMessage());
     }
   }
 }

--- a/src/main/java/com/ezylang/evalex/functions/string/StringMatchesFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/string/StringMatchesFunction.java
@@ -43,8 +43,6 @@ public class StringMatchesFunction extends AbstractFunction {
       throws EvaluationException {
     String string = parameterValues[0].getStringValue();
     String pattern = parameterValues[1].getStringValue();
-
-    return expression.convertValue(
-        RegularExpressionUtils.matches(expression, functionToken, string, pattern));
+    return RegularExpressionUtils.matches(expression, functionToken, string, pattern);
   }
 }

--- a/src/main/java/com/ezylang/evalex/functions/string/StringMatchesFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/string/StringMatchesFunction.java
@@ -23,7 +23,6 @@ import com.ezylang.evalex.functions.AbstractFunction;
 import com.ezylang.evalex.functions.FunctionParameter;
 import com.ezylang.evalex.functions.string.util.RegularExpressionUtils;
 import com.ezylang.evalex.parser.Token;
-import java.util.regex.Matcher;
 
 /**
  * Returns true if the string matches the pattern.
@@ -45,13 +44,7 @@ public class StringMatchesFunction extends AbstractFunction {
     String string = parameterValues[0].getStringValue();
     String pattern = parameterValues[1].getStringValue();
 
-    int timeout = expression.getConfiguration().getRegexTimeoutMillis();
-    Matcher safeMatcher = RegularExpressionUtils.createMatcherWithTimeout(string, pattern, timeout);
-
-    try {
-      return expression.convertValue(safeMatcher.matches());
-    } catch (IllegalStateException e) {
-      throw new EvaluationException(functionToken, e.getMessage());
-    }
+    return expression.convertValue(
+        RegularExpressionUtils.matches(expression, functionToken, string, pattern));
   }
 }

--- a/src/main/java/com/ezylang/evalex/functions/string/util/RegularExpressionUtils.java
+++ b/src/main/java/com/ezylang/evalex/functions/string/util/RegularExpressionUtils.java
@@ -17,6 +17,7 @@ package com.ezylang.evalex.functions.string.util;
 
 import com.ezylang.evalex.EvaluationException;
 import com.ezylang.evalex.Expression;
+import com.ezylang.evalex.data.EvaluationValue;
 import com.ezylang.evalex.parser.Token;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
@@ -87,15 +88,16 @@ public class RegularExpressionUtils {
    * @param token The current token from the parsed expression, for reporting purposes
    * @param string the character sequence to be searched
    * @param regex the regular expression pattern to be compiled
-   * @return true if the string matches the specified regular expression
+   * @return {@link EvaluationValue#TRUE} if the string matches the specified regular expression;
+   *     {@link EvaluationValue#FALSE}, otherwise
    * @throws EvaluationException if the regex is invalid or the evaluation runtime exceeds the
    *     maximum configured timeout
    */
-  public static boolean matches(Expression expression, Token token, String string, String regex)
-      throws EvaluationException {
+  public static EvaluationValue matches(
+      Expression expression, Token token, String string, String regex) throws EvaluationException {
     Matcher matcher = createMatcher(expression, token, string, regex);
     try {
-      return matcher.matches();
+      return expression.convertValue(matcher.matches());
     } catch (IllegalStateException e) {
       throw new EvaluationException(token, "RegEx matching timed out");
     }

--- a/src/main/java/com/ezylang/evalex/functions/string/util/RegularExpressionUtils.java
+++ b/src/main/java/com/ezylang/evalex/functions/string/util/RegularExpressionUtils.java
@@ -1,0 +1,137 @@
+/*
+  Copyright 2012-2026 Udo Klimaschewski
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+package com.ezylang.evalex.functions.string.util;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import lombok.experimental.UtilityClass;
+
+/**
+ * Utilities for working safely with Regular Expressions.
+ *
+ * <p>Inspired by https://stackoverflow.com/a/11348374 (posted by Andreas, modified by the
+ * community)
+ *
+ * @author oswaldo.bapvic.jr
+ * @since 3.6.3
+ */
+@UtilityClass
+public class RegularExpressionUtils {
+
+  /**
+   * Creates a {@link Matcher} with a specific execution timeout using a regular expression string.
+   *
+   * <p>This method compiles the provided regular expression and delegates the creation to {@link
+   * #createMatcherWithTimeout(String, Pattern, int)}.
+   *
+   * @param string the character sequence to be searched
+   * @param regex the regular expression string to be compiled
+   * @param timeoutMillis the maximum time allowed for the matching operation in milliseconds
+   * @return a {@link Matcher} configured to interrupt execution if the timeout is reached
+   * @throws java.util.regex.PatternSyntaxException if the regular expression's syntax is invalid
+   */
+  public static Matcher createMatcherWithTimeout(String string, String regex, int timeoutMillis) {
+    Pattern pattern = Pattern.compile(regex);
+    return createMatcherWithTimeout(string, pattern, timeoutMillis);
+  }
+
+  /**
+   * Creates a {@link Matcher} with a specific execution timeout using a pre-compiled {@link
+   * Pattern}.
+   *
+   * <p>The timeout mechanism is enforced by wrapping the target string inside a {@code
+   * TimeoutRegexCharSequence}, which monitors elapsed time during evaluation.
+   *
+   * @param string the character sequence to be searched
+   * @param pattern the pre-compiled {@link Pattern} object
+   * @param timeoutMillis the maximum time allowed for the matching operation in milliseconds
+   * @return a {@link Matcher} configured to interrupt execution if the timeout is reached
+   */
+  public static Matcher createMatcherWithTimeout(
+      String string, Pattern pattern, int timeoutMillis) {
+    CharSequence charSequence = new TimeoutRegexCharSequence(string, timeoutMillis);
+    return pattern.matcher(charSequence);
+  }
+
+  /**
+   * A wrapper for {@link CharSequence} that enforces a processing time limit during regex matching.
+   *
+   * <p>This class intercepts character access via {@link #charAt(int)} to check if the elapsed time
+   * exceeds the configured timeout threshold. If the limit is exceeded, it aborts execution.
+   */
+  static class TimeoutRegexCharSequence implements CharSequence {
+
+    private final CharSequence inner;
+
+    private final int timeoutMillis;
+
+    private final long timeoutTime;
+
+    /**
+     * Constructs a new {@code TimeoutRegexCharSequence} wrapper.
+     *
+     * @param inner the underlying character sequence to delegate to
+     * @param timeoutMillis the maximum allowed execution duration in milliseconds
+     */
+    public TimeoutRegexCharSequence(CharSequence inner, int timeoutMillis) {
+      this.inner = inner;
+      this.timeoutMillis = timeoutMillis;
+      timeoutTime = System.currentTimeMillis() + timeoutMillis;
+    }
+
+    /**
+     * Returns the character at the specified index, checking for execution timeout first.
+     *
+     * @param index the index of the character to return
+     * @return the character at the specified index
+     * @throws IllegalStateException if the elapsed time exceeds the configured {@code
+     *     timeoutMillis}
+     * @throws IndexOutOfBoundsException if the index is negative or not less than the length
+     */
+    public char charAt(int index) {
+      if (System.currentTimeMillis() > timeoutTime) {
+        throw new IllegalStateException("RegEx matching timed out");
+      }
+      return inner.charAt(index);
+    }
+
+    /**
+     * Returns the length of this character sequence.
+     *
+     * @return the number of characters in the underlying sequence
+     */
+    public int length() {
+      return inner.length();
+    }
+
+    /**
+     * Returns a new {@code TimeoutRegexCharSequence} that is a subsequence of this sequence.
+     *
+     * @param start the start index, inclusive
+     * @param end the end index, exclusive
+     * @return the specified subsequence wrapped in a new timeout-monitored sequence
+     * @throws IndexOutOfBoundsException if start or end are invalid relative to the length
+     */
+    public CharSequence subSequence(int start, int end) {
+      return new TimeoutRegexCharSequence(inner.subSequence(start, end), timeoutMillis);
+    }
+
+    @Override
+    public String toString() {
+      return inner.toString();
+    }
+  }
+}

--- a/src/main/java/com/ezylang/evalex/functions/string/util/RegularExpressionUtils.java
+++ b/src/main/java/com/ezylang/evalex/functions/string/util/RegularExpressionUtils.java
@@ -15,12 +15,22 @@
 */
 package com.ezylang.evalex.functions.string.util;
 
+import com.ezylang.evalex.EvaluationException;
+import com.ezylang.evalex.Expression;
+import com.ezylang.evalex.parser.Token;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 import lombok.experimental.UtilityClass;
 
 /**
- * Utilities for working safely with Regular Expressions.
+ * Utility class providing timeout-based protection for regular expression evaluations.
+ *
+ * <p><strong>Note:</strong> This utility does not modify the underlying Java regex engine. It
+ * forces a strict runtime boundary by intercepting character sequence access. If a regex evaluation
+ * runs without bounds due to complex backtracking or malicious inputs, execution is aborted once
+ * the timeout threshold is passed.
  *
  * <p>Inspired by https://stackoverflow.com/a/11348374 (posted by Andreas, modified by the
  * community)
@@ -32,78 +42,120 @@ import lombok.experimental.UtilityClass;
 public class RegularExpressionUtils {
 
   /**
-   * Creates a {@link Matcher} with a specific execution timeout using a regular expression string.
+   * Creates a {@link Matcher} bounded by a specific execution timeout.
    *
-   * <p>This method compiles the provided regular expression and delegates the creation to {@link
-   * #createMatcherWithTimeout(String, Pattern, int)}.
+   * <p>This method calculates an absolute deadline using {@link System#nanoTime()} and wraps the
+   * input sequence. The underlying regex engine will still backtrack normally, but the wrapper will
+   * abort the operation if evaluation exceeds the allowed duration.
    *
+   * @param expression the expression, where this utility is executed, to access the expression
+   *     configuration.
+   * @param token The current token from the parsed expression, for reporting purposes
    * @param string the character sequence to be searched
    * @param regex the regular expression string to be compiled
-   * @param timeoutMillis the maximum time allowed for the matching operation in milliseconds
-   * @return a {@link Matcher} configured to interrupt execution if the timeout is reached
-   * @throws java.util.regex.PatternSyntaxException if the regular expression's syntax is invalid
+   * @return a {@link Matcher} configured to throw an exception if the evaluation timeout is reached
+   * @throws EvaluationException if the regular expression's syntax is invalid
    */
-  public static Matcher createMatcherWithTimeout(String string, String regex, int timeoutMillis) {
-    Pattern pattern = Pattern.compile(regex);
-    return createMatcherWithTimeout(string, pattern, timeoutMillis);
+  private static Matcher createMatcher(
+      Expression expression, Token token, String string, String regex) throws EvaluationException {
+
+    try {
+      Pattern pattern = Pattern.compile(regex);
+      int timeoutMillis = expression.getConfiguration().getRegexTimeoutMillis();
+
+      CharSequence charSequence =
+          timeoutMillis > 0
+              ? TimeoutRegexCharSequence.withTimeoutDelta(string, timeoutMillis)
+              : string;
+
+      return pattern.matcher(charSequence);
+    } catch (PatternSyntaxException e) {
+      throw new EvaluationException(token, e.getClass().getCanonicalName() + ": " + e.getMessage());
+    }
   }
 
   /**
-   * Creates a {@link Matcher} with a specific execution timeout using a pre-compiled {@link
-   * Pattern}.
+   * Evaluates whether a given string matches a regular expression, bounding the total execution
+   * time. *
    *
-   * <p>The timeout mechanism is enforced by wrapping the target string inside a {@code
-   * TimeoutRegexCharSequence}, which monitors elapsed time during evaluation.
+   * <p>If the matching engine enters an unacceptably long evaluation path (e.g., due to
+   * catastrophic backtracking), the process is aborted via an exception rather than running
+   * indefinitely.
    *
+   * @param expression the expression, where this utility is executed, to access the expression
+   *     configuration.
+   * @param token The current token from the parsed expression, for reporting purposes
    * @param string the character sequence to be searched
-   * @param pattern the pre-compiled {@link Pattern} object
-   * @param timeoutMillis the maximum time allowed for the matching operation in milliseconds
-   * @return a {@link Matcher} configured to interrupt execution if the timeout is reached
+   * @param regex the regular expression pattern to be compiled
+   * @return true if the string matches the specified regular expression
+   * @throws EvaluationException if the regex is invalid or the evaluation runtime exceeds the
+   *     maximum configured timeout
    */
-  public static Matcher createMatcherWithTimeout(
-      String string, Pattern pattern, int timeoutMillis) {
-    CharSequence charSequence = new TimeoutRegexCharSequence(string, timeoutMillis);
-    return pattern.matcher(charSequence);
+  public static boolean matches(Expression expression, Token token, String string, String regex)
+      throws EvaluationException {
+    Matcher matcher = createMatcher(expression, token, string, regex);
+    try {
+      return matcher.matches();
+    } catch (IllegalStateException e) {
+      throw new EvaluationException(token, "RegEx matching timed out");
+    }
   }
 
   /**
-   * A wrapper for {@link CharSequence} that enforces a processing time limit during regex matching.
+   * A wrapper for {@link CharSequence} that enforces a runtime boundary during regex evaluation.
    *
-   * <p>This class intercepts character access via {@link #charAt(int)} to check if the elapsed time
-   * exceeds the configured timeout threshold. If the limit is exceeded, it aborts execution.
+   * <p>This class intercepts character access via {@link #charAt(int)} to check elapsed monotonic
+   * time. It serves as a passive circuit breaker: it does not optimize or change the backtracking
+   * behavior of the regex engine, but stops it from running indefinitely if it gets stuck in a
+   * runaway loop.
    */
   static class TimeoutRegexCharSequence implements CharSequence {
 
     private final CharSequence inner;
-
-    private final int timeoutMillis;
-
-    private final long timeoutTime;
+    private final long timeoutNano;
 
     /**
-     * Constructs a new {@code TimeoutRegexCharSequence} wrapper.
+     * Constructs a new {@code TimeoutRegexCharSequence} wrapper with an absolute nanosecond
+     * deadline.
      *
      * @param inner the underlying character sequence to delegate to
-     * @param timeoutMillis the maximum allowed execution duration in milliseconds
+     * @param timeoutNano the absolute System.nanoTime() marker when execution must abort
      */
-    public TimeoutRegexCharSequence(CharSequence inner, int timeoutMillis) {
+    TimeoutRegexCharSequence(CharSequence inner, long timeoutNano) {
       this.inner = inner;
-      this.timeoutMillis = timeoutMillis;
-      timeoutTime = System.currentTimeMillis() + timeoutMillis;
+      this.timeoutNano = timeoutNano;
     }
 
     /**
-     * Returns the character at the specified index, checking for execution timeout first.
+     * Static factory method to create a wrapper using a relative duration (delta) in milliseconds.
+     * *
+     *
+     * <p>This method computes the absolute nanosecond deadline starting from the moment it is
+     * called, making it ideal for the initial instantiation entry point.
+     *
+     * @param inner the underlying character sequence to delegate to
+     * @param timeoutMillisDelta the maximum allowed duration for evaluation in milliseconds
+     * @return a new {@code TimeoutRegexCharSequence} instance initialized with the calculated
+     *     deadline
+     */
+    public static TimeoutRegexCharSequence withTimeoutDelta(
+        CharSequence inner, int timeoutMillisDelta) {
+      long absoluteTimeoutNano =
+          System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMillisDelta);
+      return new TimeoutRegexCharSequence(inner, absoluteTimeoutNano);
+    }
+
+    /**
+     * Returns the character at the specified index, checking if the evaluation has timed out.
      *
      * @param index the index of the character to return
      * @return the character at the specified index
-     * @throws IllegalStateException if the elapsed time exceeds the configured {@code
-     *     timeoutMillis}
+     * @throws IllegalStateException if the evaluation runtime has exceeded the allowed deadline
      * @throws IndexOutOfBoundsException if the index is negative or not less than the length
      */
     @Override
     public char charAt(int index) {
-      if (System.currentTimeMillis() > timeoutTime) {
+      if (System.nanoTime() > timeoutNano) {
         throw new IllegalStateException("RegEx matching timed out");
       }
       return inner.charAt(index);
@@ -120,16 +172,16 @@ public class RegularExpressionUtils {
     }
 
     /**
-     * Returns a new {@code TimeoutRegexCharSequence} that is a subsequence of this sequence.
+     * Returns a new {@code TimeoutRegexCharSequence} sharing the exact same expiration deadline.
      *
      * @param start the start index, inclusive
      * @param end the end index, exclusive
-     * @return the specified subsequence wrapped in a new timeout-monitored sequence
+     * @return the specified subsequence wrapped in a timeout-monitored sequence
      * @throws IndexOutOfBoundsException if start or end are invalid relative to the length
      */
     @Override
     public CharSequence subSequence(int start, int end) {
-      return new TimeoutRegexCharSequence(inner.subSequence(start, end), timeoutMillis);
+      return new TimeoutRegexCharSequence(inner.subSequence(start, end), this.timeoutNano);
     }
 
     @Override

--- a/src/main/java/com/ezylang/evalex/functions/string/util/RegularExpressionUtils.java
+++ b/src/main/java/com/ezylang/evalex/functions/string/util/RegularExpressionUtils.java
@@ -101,6 +101,7 @@ public class RegularExpressionUtils {
      *     timeoutMillis}
      * @throws IndexOutOfBoundsException if the index is negative or not less than the length
      */
+    @Override
     public char charAt(int index) {
       if (System.currentTimeMillis() > timeoutTime) {
         throw new IllegalStateException("RegEx matching timed out");
@@ -113,6 +114,7 @@ public class RegularExpressionUtils {
      *
      * @return the number of characters in the underlying sequence
      */
+    @Override
     public int length() {
       return inner.length();
     }
@@ -125,6 +127,7 @@ public class RegularExpressionUtils {
      * @return the specified subsequence wrapped in a new timeout-monitored sequence
      * @throws IndexOutOfBoundsException if start or end are invalid relative to the length
      */
+    @Override
     public CharSequence subSequence(int start, int end) {
       return new TimeoutRegexCharSequence(inner.subSequence(start, end), timeoutMillis);
     }

--- a/src/test/java/com/ezylang/evalex/config/TestConfigurationProvider.java
+++ b/src/test/java/com/ezylang/evalex/config/TestConfigurationProvider.java
@@ -37,6 +37,13 @@ public class TestConfigurationProvider {
           .lenientMode(true)
           .build();
 
+  public static final ExpressionConfiguration StandardConfigurationWithoutTimeout =
+      ExpressionConfiguration.builder()
+          .zoneId(ZoneId.of("Europe/Berlin"))
+          .locale(Locale.US)
+          .regexTimeoutMillis(0)
+          .build();
+
   public static final ExpressionConfiguration StandardConfigurationWithAdditionalTestOperators =
       ExpressionConfiguration.builder()
           .zoneId(ZoneId.of("Europe/Berlin"))

--- a/src/test/java/com/ezylang/evalex/functions/string/StringFunctionsTest.java
+++ b/src/test/java/com/ezylang/evalex/functions/string/StringFunctionsTest.java
@@ -204,6 +204,57 @@ class StringFunctionsTest extends BaseEvaluationTest {
     assertExpressionHasExpectedResult(expression, expectedResult);
   }
 
+  /**
+   * Security tests for the STR_MATCHES function to validate protection against CWE-1333 (ReDoS -
+   * Regular Expression Denial of Service). See: https://github.com/ezylang/EvalEx/issues/570
+   */
+  @Test
+  void testMatchesPatternTooLong() {
+    // Pattern exceeds 100 character limit
+    String longPattern = "a".repeat(101);
+    assertThatThrownBy(() -> evaluate(String.format("STR_MATCHES(\"test\", \"%s\")", longPattern)))
+        .isInstanceOf(EvaluationException.class)
+        .hasMessageContaining("exceeds maximum length")
+        .hasMessageContaining("100");
+  }
+
+  @Test
+  void testMatchesNestedQuantifiers() {
+    // ReDoS pattern: (a+)+
+    assertThatThrownBy(() -> evaluate("STR_MATCHES(\"aaaaaaaab\", \"(a+)+b\")"))
+        .isInstanceOf(EvaluationException.class)
+        .hasMessageContaining("dangerous constructs")
+        .hasMessageContaining("ReDoS");
+  }
+
+  @Test
+  void testMatchesNestedAsterisk() {
+    // ReDoS pattern: (a*)*
+    assertThatThrownBy(() -> evaluate("STR_MATCHES(\"aaaaaaaab\", \"(a*)*b\")"))
+        .isInstanceOf(EvaluationException.class)
+        .hasMessageContaining("dangerous constructs");
+  }
+
+  @Test
+  void testMatchesCharacterClassQuantifier() {
+    // ReDoS pattern: [a]+
+    assertThatThrownBy(() -> evaluate("STR_MATCHES(\"test\", \"[a]+\")"))
+        .isInstanceOf(EvaluationException.class)
+        .hasMessageContaining("dangerous constructs");
+  }
+
+  @Test
+  void testMatchesValidPattern() throws EvaluationException, ParseException {
+    // Simple valid pattern should work
+    evaluate("STR_MATCHES(\"hello\", \"h.*o\")");
+  }
+
+  @Test
+  void testMatchesValidCharacterClass() throws EvaluationException, ParseException {
+    // Valid character class without quantifier should work
+    evaluate("STR_MATCHES(\"abc\", \"[abc]*\")");
+  }
+
   @ParameterizedTest
   @CsvSource(
       delimiter = ':',

--- a/src/test/java/com/ezylang/evalex/functions/string/StringFunctionsTest.java
+++ b/src/test/java/com/ezylang/evalex/functions/string/StringFunctionsTest.java
@@ -204,6 +204,13 @@ class StringFunctionsTest extends BaseEvaluationTest {
     assertExpressionHasExpectedResult(expression, expectedResult);
   }
 
+  @Test
+  void testMatchesInvalidPattern() throws EvaluationException, ParseException {
+    assertThatThrownBy(() -> evaluate("STR_MATCHES(\"Hello World\",\"[A-ZMatching(\")"))
+        .isInstanceOf(EvaluationException.class)
+        .hasMessageContaining("Invalid regex pattern");
+  }
+
   @ParameterizedTest
   @CsvSource(
       delimiter = ':',

--- a/src/test/java/com/ezylang/evalex/functions/string/StringFunctionsTest.java
+++ b/src/test/java/com/ezylang/evalex/functions/string/StringFunctionsTest.java
@@ -204,57 +204,6 @@ class StringFunctionsTest extends BaseEvaluationTest {
     assertExpressionHasExpectedResult(expression, expectedResult);
   }
 
-  /**
-   * Security tests for the STR_MATCHES function to validate protection against CWE-1333 (ReDoS -
-   * Regular Expression Denial of Service). See: https://github.com/ezylang/EvalEx/issues/570
-   */
-  @Test
-  void testMatchesPatternTooLong() {
-    // Pattern exceeds 100 character limit
-    String longPattern = "a".repeat(101);
-    assertThatThrownBy(() -> evaluate(String.format("STR_MATCHES(\"test\", \"%s\")", longPattern)))
-        .isInstanceOf(EvaluationException.class)
-        .hasMessageContaining("exceeds maximum length")
-        .hasMessageContaining("100");
-  }
-
-  @Test
-  void testMatchesNestedQuantifiers() {
-    // ReDoS pattern: (a+)+
-    assertThatThrownBy(() -> evaluate("STR_MATCHES(\"aaaaaaaab\", \"(a+)+b\")"))
-        .isInstanceOf(EvaluationException.class)
-        .hasMessageContaining("dangerous constructs")
-        .hasMessageContaining("ReDoS");
-  }
-
-  @Test
-  void testMatchesNestedAsterisk() {
-    // ReDoS pattern: (a*)*
-    assertThatThrownBy(() -> evaluate("STR_MATCHES(\"aaaaaaaab\", \"(a*)*b\")"))
-        .isInstanceOf(EvaluationException.class)
-        .hasMessageContaining("dangerous constructs");
-  }
-
-  @Test
-  void testMatchesCharacterClassQuantifier() {
-    // ReDoS pattern: [a]+
-    assertThatThrownBy(() -> evaluate("STR_MATCHES(\"test\", \"[a]+\")"))
-        .isInstanceOf(EvaluationException.class)
-        .hasMessageContaining("dangerous constructs");
-  }
-
-  @Test
-  void testMatchesValidPattern() throws EvaluationException, ParseException {
-    // Simple valid pattern should work
-    evaluate("STR_MATCHES(\"hello\", \"h.*o\")");
-  }
-
-  @Test
-  void testMatchesValidCharacterClass() throws EvaluationException, ParseException {
-    // Valid character class without quantifier should work
-    evaluate("STR_MATCHES(\"abc\", \"[abc]*\")");
-  }
-
   @ParameterizedTest
   @CsvSource(
       delimiter = ':',

--- a/src/test/java/com/ezylang/evalex/functions/string/StringFunctionsTest.java
+++ b/src/test/java/com/ezylang/evalex/functions/string/StringFunctionsTest.java
@@ -204,6 +204,25 @@ class StringFunctionsTest extends BaseEvaluationTest {
     assertExpressionHasExpectedResult(expression, expectedResult);
   }
 
+  @ParameterizedTest
+  @CsvSource(
+      delimiter = ':',
+      value = {
+        "STR_MATCHES(\"\", \"\") : true",
+        "STR_MATCHES(\"a\", \"a\") : true",
+        "STR_MATCHES(\"Hello World\", \"Hello\") : false",
+        "STR_MATCHES(\"Hello World\", \"hello\") : false",
+        "STR_MATCHES(\"Hello world\", \"text\") : false",
+        "STR_MATCHES(\"\", \"text\") : false",
+        "STR_MATCHES(\"Hello World\", \".*World\") : true",
+        "STR_MATCHES(\"Hello World\", \".*world\") : false",
+      })
+  void testMatchesWithoutTimeout(String expression, String expectedResult)
+      throws EvaluationException, ParseException {
+    assertExpressionHasExpectedResult(
+        expression, expectedResult, TestConfigurationProvider.StandardConfigurationWithoutTimeout);
+  }
+
   @Test
   void testMatchesTimeoutOnCatastrophicBacktracing() throws EvaluationException, ParseException {
 
@@ -213,12 +232,17 @@ class StringFunctionsTest extends BaseEvaluationTest {
     String badString = "x".repeat(5000);
     String evilExpression = String.format("STR_MATCHES(\"%s\", \"%s\")", badString, badPattern);
 
-    assertThatThrownBy(
-            () -> {
-              evaluate(evilExpression);
-            })
+    assertThatThrownBy(() -> evaluate(evilExpression))
         .isInstanceOf(EvaluationException.class)
         .hasMessage("RegEx matching timed out");
+  }
+
+  @Test
+  void testMatchesInvalidRegex() throws EvaluationException, ParseException {
+
+    assertThatThrownBy(() -> evaluate("STR_MATCHES(\"testString\", \"(invalid\")"))
+        .isInstanceOf(EvaluationException.class)
+        .hasMessageContaining("PatternSyntaxException: Unclosed group near index 8");
   }
 
   @ParameterizedTest

--- a/src/test/java/com/ezylang/evalex/functions/string/StringFunctionsTest.java
+++ b/src/test/java/com/ezylang/evalex/functions/string/StringFunctionsTest.java
@@ -205,10 +205,20 @@ class StringFunctionsTest extends BaseEvaluationTest {
   }
 
   @Test
-  void testMatchesInvalidPattern() throws EvaluationException, ParseException {
-    assertThatThrownBy(() -> evaluate("STR_MATCHES(\"Hello World\",\"[A-ZMatching(\")"))
+  void testMatchesTimeoutOnCatastrophicBacktracing() throws EvaluationException, ParseException {
+
+    // This regex pattern combined with the input creates a classic "catastrophic backtracking"
+    // scenario
+    String badPattern = "(x+x+)+y";
+    String badString = "x".repeat(5000);
+    String evilExpression = String.format("STR_MATCHES(\"%s\", \"%s\")", badString, badPattern);
+
+    assertThatThrownBy(
+            () -> {
+              evaluate(evilExpression);
+            })
         .isInstanceOf(EvaluationException.class)
-        .hasMessageContaining("Invalid regex pattern");
+        .hasMessage("RegEx matching timed out");
   }
 
   @ParameterizedTest

--- a/src/test/java/com/ezylang/evalex/functions/string/StringFunctionsTest.java
+++ b/src/test/java/com/ezylang/evalex/functions/string/StringFunctionsTest.java
@@ -224,7 +224,7 @@ class StringFunctionsTest extends BaseEvaluationTest {
   }
 
   @Test
-  void testMatchesTimeoutOnCatastrophicBacktracing() throws EvaluationException, ParseException {
+  void testMatchesTimeoutOnCatastrophicBacktracing() {
 
     // This regex pattern combined with the input creates a classic "catastrophic backtracking"
     // scenario
@@ -238,7 +238,7 @@ class StringFunctionsTest extends BaseEvaluationTest {
   }
 
   @Test
-  void testMatchesInvalidRegex() throws EvaluationException, ParseException {
+  void testMatchesInvalidRegex() {
 
     assertThatThrownBy(() -> evaluate("STR_MATCHES(\"testString\", \"(invalid\")"))
         .isInstanceOf(EvaluationException.class)

--- a/src/test/java/com/ezylang/evalex/functions/string/util/RegularExpressionUtilsTest.java
+++ b/src/test/java/com/ezylang/evalex/functions/string/util/RegularExpressionUtilsTest.java
@@ -66,7 +66,7 @@ class RegularExpressionUtilsTest {
     }
 
     @Test
-    void charSequence_SubSequence_ShouldInheritTimeoutBehavior() throws InterruptedException {
+    void charSequence_SubSequence_ShouldInheritTimeoutBehavior() {
       // Arrange
       String input = "Short-lived sequence";
       // Force a near immediate timeout without sleeping

--- a/src/test/java/com/ezylang/evalex/functions/string/util/RegularExpressionUtilsTest.java
+++ b/src/test/java/com/ezylang/evalex/functions/string/util/RegularExpressionUtilsTest.java
@@ -19,8 +19,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.ezylang.evalex.functions.string.util.RegularExpressionUtils.TimeoutRegexCharSequence;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -31,46 +29,6 @@ import org.junit.jupiter.api.Test;
  * @author oswaldo.bapvic.jr
  */
 class RegularExpressionUtilsTest {
-
-  @Test
-  void createMatcherWithTimeout_StringRegex_ShouldMatchSuccessfully() {
-    String input = "Hello, world!";
-    String regex = "Hello.*";
-    int timeout = 1000;
-
-    Matcher matcher = RegularExpressionUtils.createMatcherWithTimeout(input, regex, timeout);
-
-    assertThat(matcher.matches()).isTrue();
-  }
-
-  @Test
-  void createMatcherWithTimeout_PatternObject_ShouldMatchSuccessfully() {
-    String input = "JUnit5 test";
-    Pattern pattern = Pattern.compile("\\d+");
-    int timeout = 1000;
-
-    Matcher matcher = RegularExpressionUtils.createMatcherWithTimeout(input, pattern, timeout);
-
-    assertThat(matcher.find()).isTrue();
-    assertThat(matcher.group()).isEqualTo("5");
-  }
-
-  @Test
-  void createMatcherWithTimeout_CatastrophicBacktracking_ShouldTimeoutAndThrowException() {
-    // This regex pattern combined with the input creates a classic "catastrophic backtracking"
-    // scenario
-    String regex = "(a+a+)+y";
-    String input = "a".repeat(5000);
-    int timeoutMillis = 50;
-
-    // Act
-    Matcher matcher = RegularExpressionUtils.createMatcherWithTimeout(input, regex, timeoutMillis);
-
-    // Assert
-    assertThatThrownBy(matcher::matches)
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("RegEx matching timed out");
-  }
 
   @Nested
   class TimeoutRegexCharSequenceTest {
@@ -95,7 +53,7 @@ class RegularExpressionUtilsTest {
     void charSequence_SubSequence_ShouldReturnValidWrappedSubSequence() {
       // Arrange
       String input = "Beautiful Day";
-      var originalSequence = new TimeoutRegexCharSequence(input, 1000);
+      var originalSequence = TimeoutRegexCharSequence.withTimeoutDelta(input, 1000);
 
       // Act
       CharSequence subSeg = originalSequence.subSequence(0, 9);

--- a/src/test/java/com/ezylang/evalex/functions/string/util/RegularExpressionUtilsTest.java
+++ b/src/test/java/com/ezylang/evalex/functions/string/util/RegularExpressionUtilsTest.java
@@ -46,7 +46,7 @@ class RegularExpressionUtilsTest {
       String input = "Test String";
       var sequence = new TimeoutRegexCharSequence(input, 1000);
 
-      assertThat(sequence.toString()).isEqualTo("Test String");
+      assertThat(sequence).hasToString("Test String");
     }
 
     @Test
@@ -59,7 +59,7 @@ class RegularExpressionUtilsTest {
       CharSequence subSeg = originalSequence.subSequence(0, 9);
 
       // Assert
-      assertThat(subSeg.toString()).isEqualTo("Beautiful");
+      assertThat(subSeg).hasToString("Beautiful");
       assertThat(subSeg.length()).isEqualTo(9);
       assertThat(subSeg.charAt(0)).isEqualTo('B');
       assertThat(subSeg).isInstanceOf(TimeoutRegexCharSequence.class);
@@ -69,14 +69,12 @@ class RegularExpressionUtilsTest {
     void charSequence_SubSequence_ShouldInheritTimeoutBehavior() throws InterruptedException {
       // Arrange
       String input = "Short-lived sequence";
-      int tightTimeout = 50; // 50 milliseconds
-      var originalSequence = new TimeoutRegexCharSequence(input, tightTimeout);
+      // Force a near immediate timeout without sleeping
+      int immediateTimeout = 1; // 1 milliseconds
+      var originalSequence = new TimeoutRegexCharSequence(input, immediateTimeout);
 
       // Act
       CharSequence subSeg = originalSequence.subSequence(0, 5);
-
-      // Wait out the timeout duration
-      Thread.sleep(60);
 
       // Assert
       // The subsequence should also throw the exception because its deadline has passed

--- a/src/test/java/com/ezylang/evalex/functions/string/util/RegularExpressionUtilsTest.java
+++ b/src/test/java/com/ezylang/evalex/functions/string/util/RegularExpressionUtilsTest.java
@@ -1,0 +1,130 @@
+/*
+  Copyright 2012-2026 Udo Klimaschewski
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+package com.ezylang.evalex.functions.string.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.ezylang.evalex.functions.string.util.RegularExpressionUtils.TimeoutRegexCharSequence;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link RegularExpressionUtils}.
+ *
+ * @since 3.6.3
+ * @author oswaldo.bapvic.jr
+ */
+class RegularExpressionUtilsTest {
+
+  @Test
+  void createMatcherWithTimeout_StringRegex_ShouldMatchSuccessfully() {
+    String input = "Hello, world!";
+    String regex = "Hello.*";
+    int timeout = 1000;
+
+    Matcher matcher = RegularExpressionUtils.createMatcherWithTimeout(input, regex, timeout);
+
+    assertThat(matcher.matches()).isTrue();
+  }
+
+  @Test
+  void createMatcherWithTimeout_PatternObject_ShouldMatchSuccessfully() {
+    String input = "JUnit5 test";
+    Pattern pattern = Pattern.compile("\\d+");
+    int timeout = 1000;
+
+    Matcher matcher = RegularExpressionUtils.createMatcherWithTimeout(input, pattern, timeout);
+
+    assertThat(matcher.find()).isTrue();
+    assertThat(matcher.group()).isEqualTo("5");
+  }
+
+  @Test
+  void createMatcherWithTimeout_CatastrophicBacktracking_ShouldTimeoutAndThrowException() {
+    // This regex pattern combined with the input creates a classic "catastrophic backtracking"
+    // scenario
+    String regex = "(a+a+)+y";
+    String input = "a".repeat(5000);
+    int timeoutMillis = 50;
+
+    // Act
+    Matcher matcher = RegularExpressionUtils.createMatcherWithTimeout(input, regex, timeoutMillis);
+
+    // Assert
+    assertThatThrownBy(matcher::matches)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("RegEx matching timed out");
+  }
+
+  @Nested
+  class TimeoutRegexCharSequenceTest {
+
+    @Test
+    void charSequence_Length_ShouldReturnCorrectLength() {
+      String input = "OpenAI";
+      var sequence = new TimeoutRegexCharSequence(input, 1000);
+
+      assertThat(sequence.length()).isEqualTo(6);
+    }
+
+    @Test
+    void charSequence_ToString_ShouldReturnOriginalStringContent() {
+      String input = "Test String";
+      var sequence = new TimeoutRegexCharSequence(input, 1000);
+
+      assertThat(sequence.toString()).isEqualTo("Test String");
+    }
+
+    @Test
+    void charSequence_SubSequence_ShouldReturnValidWrappedSubSequence() {
+      // Arrange
+      String input = "Beautiful Day";
+      var originalSequence = new TimeoutRegexCharSequence(input, 1000);
+
+      // Act
+      CharSequence subSeg = originalSequence.subSequence(0, 9);
+
+      // Assert
+      assertThat(subSeg.toString()).isEqualTo("Beautiful");
+      assertThat(subSeg.length()).isEqualTo(9);
+      assertThat(subSeg.charAt(0)).isEqualTo('B');
+      assertThat(subSeg).isInstanceOf(TimeoutRegexCharSequence.class);
+    }
+
+    @Test
+    void charSequence_SubSequence_ShouldInheritTimeoutBehavior() throws InterruptedException {
+      // Arrange
+      String input = "Short-lived sequence";
+      int tightTimeout = 50; // 50 milliseconds
+      var originalSequence = new TimeoutRegexCharSequence(input, tightTimeout);
+
+      // Act
+      CharSequence subSeg = originalSequence.subSequence(0, 5);
+
+      // Wait out the timeout duration
+      Thread.sleep(60);
+
+      // Assert
+      // The subsequence should also throw the exception because its deadline has passed
+      assertThatThrownBy(() -> subSeg.charAt(0))
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("RegEx matching timed out");
+    }
+  }
+}


### PR DESCRIPTION
This PR addresses the security vulnerability reported in issue #570 by implementing a timeout on the RegEx matching operation inside the STR_MATCHES function. The timeout is configurable via a new configuration parameter 'regexTimeoutMillis' (initial/default value: 100ms).