### PR TITLE
New function DT_TRUNCATE

### DIFF
--- a/docs/references/functions.md
+++ b/docs/references/functions.md
@@ -103,6 +103,7 @@ Available through the _ExpressionConfiguration.StandardFunctionsDictionary_ cons
 | [DT_DURATION_TO_MILLIS](#dt_duration_to_millis)     | Converts the given _DURATION_ to a milliseconds value.                                                                                                                                                                                                                      | 
 | [DT_NOW](#dt_now)                                   | Produces a new _DATE_TIME_ that represents the current moment in time.                                                                                                                                                                                                      |
 | [DT_TODAY](#dt_today)                               | Produces a new _DATE_TIME_ that represents the current date, at midnight (00:00). An optional time zone can be specified, e.g. "America/Sao_Paulo", or "GMT-03:00". If no zone ID is specified, the configured zone ID is used.                                             |
+| [DT_TRUNCATE](#dt_truncate)                         | Truncates the given _DATE_TIME_ value to a specific time unit. |
 
 ---
 
@@ -2479,3 +2480,46 @@ Use this when you need a reference to today’s date without the current time co
 \* Example considering UTC as system time zone
 
 🔝 [Back to Date Time Functions](#date-time-functions) | 🔝 [Back to top](#top)
+
+
+## DT_TRUNCATE
+
+*Since: 3.8.0*
+
+The `DT_TRUNCATE` function truncates a date-time value to a specific time unit, resetting smaller units to their start value, allowing developers to normalize timestamps for groupings, reports, or interval calculations. You can optionally supply a specific time unit and a target time zone. If omitted, the day ("d") unit and the system’s configured default time zone are used.
+
+### Syntax
+
+```
+DT_TRUNCATE(value [, timeUnit [, zoneId]]
+```
+
+### Parameters
+
+| Name     | Description                                                                                                                                                                 |
+|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| value    | The `DATE_TIME` value to truncate.                                                                                                                                          |
+| timeUnit | *(Optional)* Case-sensitive formatting character. Default is `"d"`. Supported units: `"y"` (Year), `"M"` (Month), `"d"` (Day), `"H"` (Hour), `"m"` (Minute), `"s" (Second). |
+| zoneId   | *(Optional)* Time zone identifier string to use (e.g. `"UTC"`, `"America/Sao_Paulo"`). To skip `timeUnit` and pass a zone, use `NULL` for `timeUnit`.                       |
+
+
+### Examples
+
+These examples show how various combinations of units and zones affect the resulting date-time value.
+
+>**Note:** The function [DT_DATE_PARSE](#dt_date_parse) is being used to produce `DATE_TIME` values for the truncation operations.
+
+| Expression                                                                   | Result                 |
+|------------------------------------------------------------------------------|------------------------|
+| `DT_TRUNCATE(DT_DATE_PARSE("2026-08-08T14:30:45Z"))`                         | `2026-08-08T00:00:00Z` |
+| `DT_TRUNCATE(DT_DATE_PARSE("2026-08-08T14:30:45Z"), "m")`                    | `2026-08-08T14:30:00Z` |
+| `DT_TRUNCATE(DT_DATE_PARSE("2026-08-08T14:30:45Z"), "H")`                    | `2026-08-08T14:00:00Z` |
+| `DT_TRUNCATE(DT_DATE_PARSE("2026-08-08T14:30:45Z"), "d")`                    | `2026-08-08T00:00:00Z` |
+| `DT_TRUNCATE(DT_DATE_PARSE("2026-08-08T14:30:45Z"), "M")`                    | `2026-08-01T00:00:00Z` |
+| `DT_TRUNCATE(DT_DATE_PARSE("2026-08-08T14:30:45Z"), "y")`                    | `2026-01-01T00:00:00Z` |
+| `DT_TRUNCATE(DT_DATE_PARSE("2026-08-08T14:30:45Z"), "d", "America/Chicago")` | `2026-08-08T05:00:00Z` |
+
+\* Examples considering UTC as system time zone
+
+🔝 [Back to Date Time Functions](#date-time-functions) | 🔝 [Back to top](#top)
+

--- a/docs/references/functions.md
+++ b/docs/references/functions.md
@@ -2491,16 +2491,16 @@ The `DT_TRUNCATE` function truncates a date-time value to a specific time unit, 
 ### Syntax
 
 ```
-DT_TRUNCATE(value [, timeUnit [, zoneId]]
+DT_TRUNCATE(value [, timeUnit [, zoneId]])
 ```
 
 ### Parameters
 
-| Name     | Description                                                                                                                                                                 |
-|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| value    | The `DATE_TIME` value to truncate.                                                                                                                                          |
-| timeUnit | *(Optional)* Case-sensitive formatting character. Default is `"d"`. Supported units: `"y"` (Year), `"M"` (Month), `"d"` (Day), `"H"` (Hour), `"m"` (Minute), `"s" (Second). |
-| zoneId   | *(Optional)* Time zone identifier string to use (e.g. `"UTC"`, `"America/Sao_Paulo"`). To skip `timeUnit` and pass a zone, use `NULL` for `timeUnit`.                       |
+| Name     | Description                                                                                                                                                                  |
+|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| value    | The `DATE_TIME` value to truncate.                                                                                                                                           |
+| timeUnit | *(Optional)* Case-sensitive formatting character. Default is `"d"`. Supported units: `"y"` (Year), `"M"` (Month), `"d"` (Day), `"H"` (Hour), `"m"` (Minute), `"s"` (Second). |
+| zoneId   | *(Optional)* Time zone identifier string to use (e.g. `"UTC"`, `"America/Sao_Paulo"`). To skip `timeUnit` and pass a zone, use `NULL` for `timeUnit`.                        |
 
 
 ### Examples
@@ -2509,15 +2509,16 @@ These examples show how various combinations of units and zones affect the resul
 
 >**Note:** The function [DT_DATE_PARSE](#dt_date_parse) is being used to produce `DATE_TIME` values for the truncation operations.
 
-| Expression                                                                   | Result                 |
-|------------------------------------------------------------------------------|------------------------|
-| `DT_TRUNCATE(DT_DATE_PARSE("2026-08-08T14:30:45Z"))`                         | `2026-08-08T00:00:00Z` |
-| `DT_TRUNCATE(DT_DATE_PARSE("2026-08-08T14:30:45Z"), "m")`                    | `2026-08-08T14:30:00Z` |
-| `DT_TRUNCATE(DT_DATE_PARSE("2026-08-08T14:30:45Z"), "H")`                    | `2026-08-08T14:00:00Z` |
-| `DT_TRUNCATE(DT_DATE_PARSE("2026-08-08T14:30:45Z"), "d")`                    | `2026-08-08T00:00:00Z` |
-| `DT_TRUNCATE(DT_DATE_PARSE("2026-08-08T14:30:45Z"), "M")`                    | `2026-08-01T00:00:00Z` |
-| `DT_TRUNCATE(DT_DATE_PARSE("2026-08-08T14:30:45Z"), "y")`                    | `2026-01-01T00:00:00Z` |
-| `DT_TRUNCATE(DT_DATE_PARSE("2026-08-08T14:30:45Z"), "d", "America/Chicago")` | `2026-08-08T05:00:00Z` |
+| Expression                                                                       | Result                     |
+|----------------------------------------------------------------------------------|----------------------------|
+| `DT_TRUNCATE(DT_DATE_PARSE("2026-08-08T14:30:45.789Z"))`                         | `2026-08-08T00:00:00.000Z` |
+| `DT_TRUNCATE(DT_DATE_PARSE("2026-08-08T14:30:45.789Z"), "s")`                    | `2026-08-08T14:30:45.000Z` |
+| `DT_TRUNCATE(DT_DATE_PARSE("2026-08-08T14:30:45.789Z"), "m")`                    | `2026-08-08T14:30:00.000Z` |
+| `DT_TRUNCATE(DT_DATE_PARSE("2026-08-08T14:30:45.789Z"), "H")`                    | `2026-08-08T14:00:00.000Z` |
+| `DT_TRUNCATE(DT_DATE_PARSE("2026-08-08T14:30:45.789Z"), "d")`                    | `2026-08-08T00:00:00.000Z` |
+| `DT_TRUNCATE(DT_DATE_PARSE("2026-08-08T14:30:45.789Z"), "M")`                    | `2026-08-01T00:00:00.000Z` |
+| `DT_TRUNCATE(DT_DATE_PARSE("2026-08-08T14:30:45.789Z"), "y")`                    | `2026-01-01T00:00:00.000Z` |
+| `DT_TRUNCATE(DT_DATE_PARSE("2026-08-08T14:30:45.789Z"), "d", "America/Chicago")` | `2026-08-08T05:00:00.000Z` |
 
 \* Examples considering UTC as system time zone
 

--- a/src/main/java/com/ezylang/evalex/config/ExpressionConfiguration.java
+++ b/src/main/java/com/ezylang/evalex/config/ExpressionConfiguration.java
@@ -44,6 +44,7 @@ import com.ezylang.evalex.functions.datetime.DateTimeNowFunction;
 import com.ezylang.evalex.functions.datetime.DateTimeParseFunction;
 import com.ezylang.evalex.functions.datetime.DateTimeToEpochFunction;
 import com.ezylang.evalex.functions.datetime.DateTimeTodayFunction;
+import com.ezylang.evalex.functions.datetime.DateTimeTruncateFunction;
 import com.ezylang.evalex.functions.datetime.DurationFromMillisFunction;
 import com.ezylang.evalex.functions.datetime.DurationNewFunction;
 import com.ezylang.evalex.functions.datetime.DurationParseFunction;
@@ -300,7 +301,8 @@ public class ExpressionConfiguration {
           Map.entry("DT_DURATION_TO_MILLIS", new DurationToMillisFunction()),
           Map.entry("DT_DURATION_PARSE", new DurationParseFunction()),
           Map.entry("DT_NOW", new DateTimeNowFunction()),
-          Map.entry("DT_TODAY", new DateTimeTodayFunction()));
+          Map.entry("DT_TODAY", new DateTimeTodayFunction()),
+          Map.entry("DT_TRUNCATE", new DateTimeTruncateFunction()));
 
   /** The math context to use. */
   @Builder.Default private final MathContext mathContext = DEFAULT_MATH_CONTEXT;

--- a/src/main/java/com/ezylang/evalex/functions/datetime/DateTimeTruncateFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/datetime/DateTimeTruncateFunction.java
@@ -1,0 +1,156 @@
+/*
+  Copyright 2012-2026 Udo Klimaschewski
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+package com.ezylang.evalex.functions.datetime;
+
+import com.ezylang.evalex.EvaluationException;
+import com.ezylang.evalex.Expression;
+import com.ezylang.evalex.data.EvaluationValue;
+import com.ezylang.evalex.functions.AbstractFunction;
+import com.ezylang.evalex.functions.FunctionParameter;
+import com.ezylang.evalex.parser.Token;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalAdjusters;
+import java.util.Map;
+
+/**
+ * An EvalEx library function that truncates an Instant date-time value to a specific time unit,
+ * allowing developers to normalize timestamps for groupings, reports, or interval calculations.
+ *
+ * <p>To maximize usability and maintain strict internal consistency within the EvalEx ecosystem,
+ * this function utilizes standard Java {@link java.time.format.DateTimeFormatter} single-character
+ * format tokens. It follows a strict positional argument pattern for its optional parameters; if
+ * you wish to skip the {@code timeUnit} parameter but specify a custom {@code zoneId}, you must
+ * pass an explicit {@code NULL} as the second argument.
+ *
+ * <h3>Syntax</h3>
+ *
+ * {@code DT_TRUNCATE(dateTime [, timeUnit [, zoneId]])}
+ *
+ * <h3>Function Parameters</h3>
+ *
+ * <ul>
+ *   <li><b>dateTime</b> - the date-time value to truncate.
+ *   <li><b>timeUnit</b> - <i>(Optional)</i> a string containing a valid case-sensitive formatting
+ *       character. Defaults to {@code 'd'} (Day) if omitted or set to {@code NULL}:
+ *       <ul>
+ *         <li>{@code 'y'} or {@code 'u'} - Truncates to the start of the <b>Year</b>.
+ *         <li>{@code 'M'} - Truncates to the start of the <b>Month</b> (Uppercase)
+ *         <li>{@code 'd'} - Truncates to the start of the <b>Day</b>
+ *         <li>{@code 'H'} - Truncates to the start of the <b>Hour</b> (Uppercase)
+ *         <li>{@code 'm'} - Truncates to the start of the <b>Minute</b> (Lowercase)
+ *         <li>{@code 's'} - Truncates to the start of the <b>Second</b>
+ *       </ul>
+ *   <li><b>zoneId</b> - <i>(Optional)</i> A string representing a valid Java ZoneId. Defaults to
+ *       the expression configuration's time zone if omitted or set to {@code NULL}.
+ * </ul>
+ *
+ * <h3>Examples</h3>
+ *
+ * Assuming UTC is the system default time zone, and the variable {@code dt} represents {@code
+ * 2026-08-08T14:30:45Z}:
+ *
+ * <pre>
+ *   DT_TRUNCATE(dt)                          -&gt; 2026-08-08T00:00:00Z (Truncated to Day)
+ *   DT_TRUNCATE(dt, "M")                     -&gt; 2026-08-01T00:00:00Z (Truncated to Month)
+ *   DT_TRUNCATE(dt, "H")                     -&gt; 2026-08-08T14:00:00Z (Truncated to Hour)
+ *   DT_TRUNCATE(dt, NULL, "America/Chicago") -&gt; 2026-08-08T05:00:00Z (Truncated to Day in Chicago time)
+ * </pre>
+ *
+ * *
+ *
+ * @author oswaldo.bapvic.jr
+ * @since 3.8.0
+ */
+@FunctionParameter(name = "dateTime")
+@FunctionParameter(name = "optionalParams", isVarArg = true) // timeUnit and zoneId
+public class DateTimeTruncateFunction extends AbstractFunction {
+
+  private static final String DEFAULT_TIME_UNIT = "d";
+
+  private static final Map<String, ChronoUnit> JAVA_FORMAT_MAPPING =
+      Map.of(
+          DEFAULT_TIME_UNIT,
+          ChronoUnit.DAYS,
+          "y",
+          ChronoUnit.YEARS,
+          "M",
+          ChronoUnit.MONTHS,
+          "H",
+          ChronoUnit.HOURS,
+          "m",
+          ChronoUnit.MINUTES,
+          "s",
+          ChronoUnit.SECONDS);
+
+  @Override
+  public EvaluationValue evaluate(
+      Expression expression, Token functionToken, EvaluationValue... parameterValues)
+      throws EvaluationException {
+
+    Instant instant = parameterValues[0].getDateTimeValue();
+
+    // Resolve the time unit
+    String unitToken =
+        (parameterValues.length > 1 && !parameterValues[1].isNullValue())
+            ? parameterValues[1].getStringValue().trim()
+            : DEFAULT_TIME_UNIT;
+
+    ChronoUnit unit = JAVA_FORMAT_MAPPING.get(unitToken);
+    if (unit == null) {
+      throw new EvaluationException(
+          functionToken,
+          String.format(
+              "Invalid time unit '%s'. Use standard Java format tokens: 'y', 'M', 'd', 'H', 'm',"
+                  + " 's'.",
+              unitToken));
+    }
+
+    // Resolve the time zone
+    ZoneId zoneId = expression.getConfiguration().getZoneId();
+    if (parameterValues.length > 2 && !parameterValues[2].isNullValue()) {
+      String zoneString = parameterValues[2].getStringValue().trim();
+      try {
+        zoneId = ZoneId.of(zoneString);
+      } catch (Exception e) {
+        throw new EvaluationException(
+            functionToken, "Time zone with id '" + zoneString + "' not found");
+      }
+    }
+
+    // Apply truncation
+    LocalDateTime localDateTime = LocalDateTime.ofInstant(instant, zoneId);
+    LocalDateTime truncatedDateTime;
+    switch (unit) {
+      case YEARS:
+        truncatedDateTime =
+            localDateTime.truncatedTo(ChronoUnit.DAYS).with(TemporalAdjusters.firstDayOfYear());
+        break;
+      case MONTHS:
+        truncatedDateTime =
+            localDateTime.truncatedTo(ChronoUnit.DAYS).with(TemporalAdjusters.firstDayOfMonth());
+        break;
+      default:
+        truncatedDateTime = localDateTime.truncatedTo(unit);
+        break;
+    }
+
+    Instant resultInstant = truncatedDateTime.atZone(zoneId).toInstant();
+    return EvaluationValue.dateTimeValue(resultInstant);
+  }
+}

--- a/src/main/java/com/ezylang/evalex/functions/datetime/DateTimeTruncateFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/datetime/DateTimeTruncateFunction.java
@@ -22,8 +22,8 @@ import com.ezylang.evalex.functions.AbstractFunction;
 import com.ezylang.evalex.functions.FunctionParameter;
 import com.ezylang.evalex.parser.Token;
 import java.time.Instant;
-import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalAdjusters;
 import java.util.Map;
@@ -49,7 +49,7 @@ import java.util.Map;
  *   <li><b>timeUnit</b> - <i>(Optional)</i> a string containing a valid case-sensitive formatting
  *       character. Defaults to {@code 'd'} (Day) if omitted or set to {@code NULL}:
  *       <ul>
- *         <li>{@code 'y'} or {@code 'u'} - Truncates to the start of the <b>Year</b>.
+ *         <li>{@code 'y'} - Truncates to the start of the <b>Year</b>.
  *         <li>{@code 'M'} - Truncates to the start of the <b>Month</b> (Uppercase)
  *         <li>{@code 'd'} - Truncates to the start of the <b>Day</b>
  *         <li>{@code 'H'} - Truncates to the start of the <b>Hour</b> (Uppercase)
@@ -134,8 +134,8 @@ public class DateTimeTruncateFunction extends AbstractFunction {
     }
 
     // Apply truncation
-    LocalDateTime localDateTime = LocalDateTime.ofInstant(instant, zoneId);
-    LocalDateTime truncatedDateTime;
+    ZonedDateTime localDateTime = ZonedDateTime.ofInstant(instant, zoneId);
+    ZonedDateTime truncatedDateTime;
     switch (unit) {
       case YEARS:
         truncatedDateTime =
@@ -150,7 +150,23 @@ public class DateTimeTruncateFunction extends AbstractFunction {
         break;
     }
 
-    Instant resultInstant = truncatedDateTime.atZone(zoneId).toInstant();
+    Instant resultInstant = truncatedDateTime.toInstant();
     return EvaluationValue.dateTimeValue(resultInstant);
+  }
+
+  @Override
+  public void validatePreEvaluation(Token token, EvaluationValue... parameterValues)
+      throws EvaluationException {
+    super.validatePreEvaluation(token, parameterValues);
+    if (parameterValues.length > 3) {
+      throw new EvaluationException(token, "Too many parameters");
+    }
+    if (!parameterValues[0].isDateTimeValue()) {
+      throw new EvaluationException(
+          token,
+          String.format(
+              "Unable to format a '%s' type as a date-time",
+              parameterValues[0].getDataType().name()));
+    }
   }
 }

--- a/src/test/java/com/ezylang/evalex/BaseEvaluationTest.java
+++ b/src/test/java/com/ezylang/evalex/BaseEvaluationTest.java
@@ -21,6 +21,8 @@ import com.ezylang.evalex.config.ExpressionConfiguration;
 import com.ezylang.evalex.config.TestConfigurationProvider;
 import com.ezylang.evalex.data.EvaluationValue;
 import com.ezylang.evalex.parser.ParseException;
+import java.time.Instant;
+import java.time.ZonedDateTime;
 
 public abstract class BaseEvaluationTest {
 
@@ -39,6 +41,15 @@ public abstract class BaseEvaluationTest {
       throws EvaluationException, ParseException {
     assertThat(evaluate(expression, expressionConfiguration).getStringValue())
         .isEqualTo(expectedResult);
+  }
+
+  protected void assertExpressionHasExpectedInstant(
+      String expression,
+      ZonedDateTime expectedResult,
+      ExpressionConfiguration expressionConfiguration)
+      throws EvaluationException, ParseException {
+    assertThat(evaluate(expression, expressionConfiguration).getDateTimeValue())
+        .isEqualTo(Instant.from(expectedResult));
   }
 
   protected EvaluationValue evaluate(String expression) throws EvaluationException, ParseException {

--- a/src/test/java/com/ezylang/evalex/functions/datetime/DateTimeFunctionsTest.java
+++ b/src/test/java/com/ezylang/evalex/functions/datetime/DateTimeFunctionsTest.java
@@ -353,40 +353,48 @@ class DateTimeFunctionsTest extends BaseEvaluationTest {
       delimiter = '|',
       value = {
         // single parameter -> assumes o day ('d') at the zone of Berlin (default)
-        "DT_TRUNCATE(DT_DATE_PARSE(\"2026-08-08T14:30:45\"))        |"
-            + " 2026-08-08T00:00:00+02:00[Europe/Berlin]",
+        "DT_TRUNCATE(DT_DATE_PARSE(\"2026-08-08T14:30:45.789\")) |"
+            + " 2026-08-08T00:00:00.000+02:00[Europe/Berlin]",
 
         // explicit unit year ('y') at the zone of Berlin
-        "DT_TRUNCATE(DT_DATE_PARSE(\"2026-08-08T14:30:45\"), \"y\") |"
-            + " 2026-01-01T00:00:00+01:00[Europe/Berlin]",
+        "DT_TRUNCATE(DT_DATE_PARSE(\"2026-08-08T14:30:45.789\"), \"y\") |"
+            + " 2026-01-01T00:00:00.000+01:00[Europe/Berlin]",
 
         // explicit unit month ('M') at the zone of Berlin
-        "DT_TRUNCATE(DT_DATE_PARSE(\"2026-08-08T14:30:45\"), \"M\") |"
-            + " 2026-08-01T00:00:00+02:00[Europe/Berlin]",
+        "DT_TRUNCATE(DT_DATE_PARSE(\"2026-08-08T14:30:45.789\"), \"M\") |"
+            + " 2026-08-01T00:00:00.000+02:00[Europe/Berlin]",
 
         // explicit unit day ('d') at the zone of Berlin
-        "DT_TRUNCATE(DT_DATE_PARSE(\"2026-08-08T14:30:45\"), \"d\") |"
-            + " 2026-08-08T00:00:00+02:00[Europe/Berlin]",
+        "DT_TRUNCATE(DT_DATE_PARSE(\"2026-08-08T14:30:45.789\"), \"d\") |"
+            + " 2026-08-08T00:00:00.000+02:00[Europe/Berlin]",
 
         // explicit unit hour ('s') at the zone of Berlin
-        "DT_TRUNCATE(DT_DATE_PARSE(\"2026-08-08T14:30:45\"), \"H\") |"
-            + " 2026-08-08T14:00:00+02:00[Europe/Berlin]",
+        "DT_TRUNCATE(DT_DATE_PARSE(\"2026-08-08T14:30:45.789\"), \"H\") |"
+            + " 2026-08-08T14:00:00.000+02:00[Europe/Berlin]",
 
         // explicit unit minute ('m') at the zone of Berlin
-        "DT_TRUNCATE(DT_DATE_PARSE(\"2026-08-08T14:30:45\"), \"m\") |"
-            + " 2026-08-08T14:30:00+02:00[Europe/Berlin]",
+        "DT_TRUNCATE(DT_DATE_PARSE(\"2026-08-08T14:30:45.789\"), \"m\") |"
+            + " 2026-08-08T14:30:00.000+02:00[Europe/Berlin]",
+
+        // explicit unit seconds ('s') at the zone of Berlin
+        "DT_TRUNCATE(DT_DATE_PARSE(\"2026-08-08T14:30:45.789\"), \"s\") |"
+            + " 2026-08-08T14:30:45.000+02:00[Europe/Berlin]",
 
         // explicit zone with null time unit -> assumes 'd' (day) at the specified zone
-        "DT_TRUNCATE(DT_DATE_PARSE(\"2026-08-08T14:30:45-03:00[America/Sao_Paulo]\"), NULL,"
-            + " \"America/Sao_Paulo\") | 2026-08-08T00:00:00-03:00[America/Sao_Paulo]",
+        "DT_TRUNCATE(DT_DATE_PARSE(\"2026-08-08T14:30:45.789-03:00[America/Sao_Paulo]\"), NULL,"
+            + " \"America/Sao_Paulo\") | 2026-08-08T00:00:00.000-03:00[America/Sao_Paulo]",
 
         // explicit unit and zone
-        "DT_TRUNCATE(DT_DATE_PARSE(\"2026-08-08T14:30:45-03:00[America/Sao_Paulo]\"), \"H\","
-            + " \"America/Sao_Paulo\") | 2026-08-08T14:00:00-03:00[America/Sao_Paulo]",
+        "DT_TRUNCATE(DT_DATE_PARSE(\"2026-08-08T14:30:45.789-03:00[America/Sao_Paulo]\"), \"H\","
+            + " \"America/Sao_Paulo\") | 2026-08-08T14:00:00.000-03:00[America/Sao_Paulo]",
+
+        // explicit unit and zone with daylight saving hour overlap scenario
+        "DT_TRUNCATE(DT_DATE_PARSE(\"2026-11-01T06:30:12.345Z\"), \"H\", \"America/New_York\") |"
+            + "2026-11-01T06:00:00.000Z", // not T05:00Z
 
         // explicit null unit and zone, apply defaults
-        "DT_TRUNCATE(DT_DATE_PARSE(\"2026-08-08T14:30:45\"), null, null) |"
-            + " 2026-08-08T00:00:00+02:00[Europe/Berlin]",
+        "DT_TRUNCATE(DT_DATE_PARSE(\"2026-08-08T14:30:45.789\"), null, null) |"
+            + " 2026-08-08T00:00:00.000+02:00[Europe/Berlin]",
       })
   void testDateTimeTruncate(String expression, String expectedResult)
       throws EvaluationException, ParseException {
@@ -399,7 +407,9 @@ class DateTimeFunctionsTest extends BaseEvaluationTest {
       delimiter = '|',
       value = {
         "DT_TRUNCATE(dt, \"i\") | Invalid time unit 'i'",
-        "DT_TRUNCATE(dt, \"d\", \"t\") | Time zone with id 't' not found"
+        "DT_TRUNCATE(dt, \"d\", \"t\") | Time zone with id 't' not found",
+        "DT_TRUNCATE(dt, \"d\", \"America/Sao_Paulo\", \"extra\") | Too many parameters",
+        "DT_TRUNCATE(\"invalid\") | Unable to format a 'STRING' type as a date-time"
       })
   void testDateTimeTruncateExceptions(String expression, String errorMessageFragment)
       throws EvaluationException, ParseException {

--- a/src/test/java/com/ezylang/evalex/functions/datetime/DateTimeFunctionsTest.java
+++ b/src/test/java/com/ezylang/evalex/functions/datetime/DateTimeFunctionsTest.java
@@ -28,6 +28,7 @@ import com.ezylang.evalex.parser.ParseException;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Locale;
 import org.junit.jupiter.api.Test;
@@ -345,5 +346,66 @@ class DateTimeFunctionsTest extends BaseEvaluationTest {
             .locale(Locale.US)
             .zoneId(ZoneId.of("America/Chicago"))
             .build());
+  }
+
+  @ParameterizedTest
+  @CsvSource(
+      delimiter = '|',
+      value = {
+        // single parameter -> assumes o day ('d') at the zone of Berlin (default)
+        "DT_TRUNCATE(DT_DATE_PARSE(\"2026-08-08T14:30:45\"))        |"
+            + " 2026-08-08T00:00:00+02:00[Europe/Berlin]",
+
+        // explicit unit year ('y') at the zone of Berlin
+        "DT_TRUNCATE(DT_DATE_PARSE(\"2026-08-08T14:30:45\"), \"y\") |"
+            + " 2026-01-01T00:00:00+01:00[Europe/Berlin]",
+
+        // explicit unit month ('M') at the zone of Berlin
+        "DT_TRUNCATE(DT_DATE_PARSE(\"2026-08-08T14:30:45\"), \"M\") |"
+            + " 2026-08-01T00:00:00+02:00[Europe/Berlin]",
+
+        // explicit unit day ('d') at the zone of Berlin
+        "DT_TRUNCATE(DT_DATE_PARSE(\"2026-08-08T14:30:45\"), \"d\") |"
+            + " 2026-08-08T00:00:00+02:00[Europe/Berlin]",
+
+        // explicit unit hour ('s') at the zone of Berlin
+        "DT_TRUNCATE(DT_DATE_PARSE(\"2026-08-08T14:30:45\"), \"H\") |"
+            + " 2026-08-08T14:00:00+02:00[Europe/Berlin]",
+
+        // explicit unit minute ('m') at the zone of Berlin
+        "DT_TRUNCATE(DT_DATE_PARSE(\"2026-08-08T14:30:45\"), \"m\") |"
+            + " 2026-08-08T14:30:00+02:00[Europe/Berlin]",
+
+        // explicit zone with null time unit -> assumes 'd' (day) at the specified zone
+        "DT_TRUNCATE(DT_DATE_PARSE(\"2026-08-08T14:30:45-03:00[America/Sao_Paulo]\"), NULL,"
+            + " \"America/Sao_Paulo\") | 2026-08-08T00:00:00-03:00[America/Sao_Paulo]",
+
+        // explicit unit and zone
+        "DT_TRUNCATE(DT_DATE_PARSE(\"2026-08-08T14:30:45-03:00[America/Sao_Paulo]\"), \"H\","
+            + " \"America/Sao_Paulo\") | 2026-08-08T14:00:00-03:00[America/Sao_Paulo]",
+
+        // explicit null unit and zone, apply defaults
+        "DT_TRUNCATE(DT_DATE_PARSE(\"2026-08-08T14:30:45\"), null, null) |"
+            + " 2026-08-08T00:00:00+02:00[Europe/Berlin]",
+      })
+  void testDateTimeTruncate(String expression, String expectedResult)
+      throws EvaluationException, ParseException {
+    ZonedDateTime expectedInstant = ZonedDateTime.parse(expectedResult);
+    assertExpressionHasExpectedInstant(expression, expectedInstant, DateTimeTestConfiguration);
+  }
+
+  @ParameterizedTest
+  @CsvSource(
+      delimiter = '|',
+      value = {
+        "DT_TRUNCATE(dt, \"i\") | Invalid time unit 'i'",
+        "DT_TRUNCATE(dt, \"d\", \"t\") | Time zone with id 't' not found"
+      })
+  void testDateTimeTruncateExceptions(String expression, String errorMessageFragment)
+      throws EvaluationException, ParseException {
+
+    assertThatThrownBy(() -> new Expression(expression).with("dt", Instant.now()).evaluate())
+        .isInstanceOf(EvaluationException.class)
+        .hasMessageContaining(errorMessageFragment);
   }
 }


### PR DESCRIPTION
## Enhancement
This PR introduces an essential data-engineering feature: the `DT_TRUNCATE` function. 

Truncating timestamps is a fundamental operation for normalizing temporal data, especially when generating business reports, grouping metrics by specific intervals (hourly, daily, monthly), or stripping time components for date-only comparisons.

### Examples

| Expression                                                                   | Result                 |
|------------------------------------------------------------------------------|------------------------|
| `DT_TRUNCATE(DT_DATE_PARSE("2026-08-08T14:30:45Z"), "m")`                    | `2026-08-08T14:30:00Z` |
| `DT_TRUNCATE(DT_DATE_PARSE("2026-08-08T14:30:45Z"), "H")`                    | `2026-08-08T14:00:00Z` |
| `DT_TRUNCATE(DT_DATE_PARSE("2026-08-08T14:30:45Z"), "d")`                    | `2026-08-08T00:00:00Z` |
| `DT_TRUNCATE(DT_DATE_PARSE("2026-08-08T14:30:45Z"), "M")`                    | `2026-08-01T00:00:00Z` |
| `DT_TRUNCATE(DT_DATE_PARSE("2026-08-08T14:30:45Z"), "y")`                    | `2026-01-01T00:00:00Z` |

### Market Alignment & Justification
Major data processing and enterprise systems offer dedicated capabilities for this exact use case, highlighting its demand:
- **Relational Databases (Oracle, Snowflake, PostgreSQL):** Heavily rely on functions like `TRUNC(date, format)` or `DATE_TRUNC('unit', date)`.
- **Integration Engines (MuleSoft/DataWeave):** Lack a direct function, forcing developers into anti-patterns like manually calculating and subtracting periods (`now() - seconds(now().seconds)`) or reconstructing nested objects component by component.
- **Spreadsheets (Excel/Google Sheets):** Force users into long, nested combinations like `DATE(YEAR(A1), MONTH(A1), 1)` just to truncate to the start of a month.

By introducing `DT_TRUNCATE`, EvalEx bridges this gap, giving users a clean, high-performance, single-function alternative to nested or mathematical date logic.

### Architectural Design Choices
To ensure seamless integration with EvalEx's core philosophies, the function was designed with the following principles:
1. **Internal Consistency:** Instead of inventing a proprietary vocabulary for time units, it leverages the standard Java `DateTimeFormatter` characters (`y`, `M`, `d`, `H`, `m`, `s`). Users who already write masks for `DT_DATE_FORMAT` will immediately know how to use this function without a learning curve.
2. **Strict Case-Sensitivity:** By strictly preserving character casing, we cleanly separate calendar units from time fractions, completely avoiding the universal conflict between **M**onth (`"M"`) and **m**inute (`"m"`).
3. **Positional Parameter Flexibility:** Following EvalEx's native pattern for optional arguments (like `DT_DATE_PARSE`), parameters default sensibly (`timeUnit` defaults to day `"d"`, and `zoneId` defaults to the expression configuration). Bypassing the middle argument to supply a custom zone is gracefully handled via `NULL` (e.g., `DT_TRUNCATE(dt, NULL, "America/Chicago")`).
4. **TimeZone Aware Instant Conversion:** Since `EvaluationValue` holds times as UTC `Instant` objects, the truncation boundaries are safely evaluated from a local calendar perspective using `ZoneId` before wrapping back into an `Instant`, protecting the engine from CI/CD pipeline environment shifts.

## Changes Included
- **Core Feature:** `DateTimeTruncateFunction.java` implementation.
- **Test Coverage:** Added new tests into `DateTimeFunctionsTest.java`.
- **Documentation:** Updated the markdown documentation following the exact table structure, styling, and UTC examples found in sibling functions like `DT_DATE_FORMAT`.
