### PR TITLE
Resolve ambiguous postfix and infix operators

### DIFF
--- a/src/main/java/com/ezylang/evalex/parser/Tokenizer.java
+++ b/src/main/java/com/ezylang/evalex/parser/Tokenizer.java
@@ -244,15 +244,9 @@ public class Tokenizer {
       }
     }
     String tokenString = tokenValue.toString();
-    if (prefixOperatorAllowed() && operatorDictionary.hasPrefixOperator(tokenString)) {
-      OperatorIfc operator = operatorDictionary.getPrefixOperator(tokenString);
-      return new Token(tokenStartIndex, tokenString, TokenType.PREFIX_OPERATOR, operator);
-    } else if (postfixOperatorAllowed() && operatorDictionary.hasPostfixOperator(tokenString)) {
-      OperatorIfc operator = operatorDictionary.getPostfixOperator(tokenString);
-      return new Token(tokenStartIndex, tokenString, TokenType.POSTFIX_OPERATOR, operator);
-    } else if (operatorDictionary.hasInfixOperator(tokenString)) {
-      OperatorIfc operator = operatorDictionary.getInfixOperator(tokenString);
-      return new Token(tokenStartIndex, tokenString, TokenType.INFIX_OPERATOR, operator);
+    Token operatorToken = createOperatorToken(tokenStartIndex, tokenString);
+    if (operatorToken != null) {
+      return operatorToken;
     } else if (tokenString.equals(".") && configuration.isStructuresAllowed()) {
       return new Token(tokenStartIndex, tokenString, STRUCTURE_SEPARATOR);
     }
@@ -261,6 +255,52 @@ public class Tokenizer {
         tokenStartIndex + tokenString.length() - 1,
         tokenString,
         "Undefined operator '" + tokenString + "'");
+  }
+
+  private Token createOperatorToken(int tokenStartIndex, String tokenString) {
+    if (prefixOperatorAllowed() && operatorDictionary.hasPrefixOperator(tokenString)) {
+      OperatorIfc operator = operatorDictionary.getPrefixOperator(tokenString);
+      return new Token(tokenStartIndex, tokenString, TokenType.PREFIX_OPERATOR, operator);
+    }
+
+    if (postfixOperatorAllowed() && operatorDictionary.hasPostfixOperator(tokenString)) {
+      if (infixOperatorAllowed()
+          && operatorDictionary.hasInfixOperator(tokenString)
+          && nextTokenCanStartInfixOperand()) {
+        OperatorIfc operator = operatorDictionary.getInfixOperator(tokenString);
+        return new Token(tokenStartIndex, tokenString, TokenType.INFIX_OPERATOR, operator);
+      }
+      OperatorIfc operator = operatorDictionary.getPostfixOperator(tokenString);
+      return new Token(tokenStartIndex, tokenString, TokenType.POSTFIX_OPERATOR, operator);
+    }
+
+    if (operatorDictionary.hasInfixOperator(tokenString)) {
+      OperatorIfc operator = operatorDictionary.getInfixOperator(tokenString);
+      return new Token(tokenStartIndex, tokenString, TokenType.INFIX_OPERATOR, operator);
+    }
+
+    return null;
+  }
+
+  /**
+   * Checks an ambiguous postfix/infix operator by parsing the following token in the context of an
+   * expected right operand. The lookahead tokenizer uses the same lexical rules as the actual
+   * tokenizer and does not modify the current tokenizer state.
+   */
+  private boolean nextTokenCanStartInfixOperand() {
+    Tokenizer lookaheadTokenizer = new Tokenizer(expressionString, configuration);
+    lookaheadTokenizer.currentColumnIndex = currentColumnIndex;
+    lookaheadTokenizer.currentChar = currentChar;
+    lookaheadTokenizer.braceBalance = braceBalance;
+    lookaheadTokenizer.arrayBalance = arrayBalance;
+    lookaheadTokenizer.tokens.add(new Token(0, "", INFIX_OPERATOR));
+
+    try {
+      Token nextToken = lookaheadTokenizer.getNextToken();
+      return nextToken != null && !invalidTokenAfterInfixOperator(nextToken);
+    } catch (ParseException exception) {
+      return false;
+    }
   }
 
   private boolean arrayOpenOrStructureSeparatorNotAllowed() {
@@ -428,24 +468,9 @@ public class Tokenizer {
     }
     String tokenName = tokenValue.toString();
 
-    if (prefixOperatorAllowed() && operatorDictionary.hasPrefixOperator(tokenName)) {
-      return new Token(
-          tokenStartIndex,
-          tokenName,
-          TokenType.PREFIX_OPERATOR,
-          operatorDictionary.getPrefixOperator(tokenName));
-    } else if (postfixOperatorAllowed() && operatorDictionary.hasPostfixOperator(tokenName)) {
-      return new Token(
-          tokenStartIndex,
-          tokenName,
-          TokenType.POSTFIX_OPERATOR,
-          operatorDictionary.getPostfixOperator(tokenName));
-    } else if (operatorDictionary.hasInfixOperator(tokenName)) {
-      return new Token(
-          tokenStartIndex,
-          tokenName,
-          TokenType.INFIX_OPERATOR,
-          operatorDictionary.getInfixOperator(tokenName));
+    Token operatorToken = createOperatorToken(tokenStartIndex, tokenName);
+    if (operatorToken != null) {
+      return operatorToken;
     }
 
     skipBlanks();

--- a/src/test/java/com/ezylang/evalex/parser/TokenizerAmbiguousOperatorTest.java
+++ b/src/test/java/com/ezylang/evalex/parser/TokenizerAmbiguousOperatorTest.java
@@ -1,0 +1,144 @@
+/*
+  Copyright 2012-2022 Udo Klimaschewski
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+package com.ezylang.evalex.parser;
+
+import static com.ezylang.evalex.operators.OperatorIfc.OPERATOR_PRECEDENCE_MULTIPLICATIVE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.ezylang.evalex.EvaluationException;
+import com.ezylang.evalex.Expression;
+import com.ezylang.evalex.config.ExpressionConfiguration;
+import com.ezylang.evalex.data.EvaluationValue;
+import com.ezylang.evalex.operators.AbstractOperator;
+import com.ezylang.evalex.operators.PostfixOperator;
+import com.ezylang.evalex.operators.arithmetic.InfixModuloOperator;
+import com.ezylang.evalex.parser.Token.TokenType;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class TokenizerAmbiguousOperatorTest extends BaseParserTest {
+
+  @BeforeEach
+  void setup() {
+    configuration =
+        ExpressionConfiguration.defaultConfiguration()
+            .withAdditionalOperators(
+                Map.entry("%", new PostfixPercentOperator()),
+                Map.entry("PERCENT", new InfixModuloOperator()),
+                Map.entry("PERCENT", new PostfixPercentOperator()));
+  }
+
+  @Test
+  void testSymbolicOperatorIsInfixBeforeNumber() throws ParseException {
+    assertAllTokensParsedCorrectly(
+        "99 % 100",
+        new Token(1, "99", TokenType.NUMBER_LITERAL),
+        new Token(4, "%", TokenType.INFIX_OPERATOR),
+        new Token(6, "100", TokenType.NUMBER_LITERAL));
+  }
+
+  @Test
+  void testSymbolicOperatorIsPostfixAtEndOfExpression() throws ParseException {
+    assertAllTokensParsedCorrectly(
+        "99%",
+        new Token(1, "99", TokenType.NUMBER_LITERAL),
+        new Token(3, "%", TokenType.POSTFIX_OPERATOR));
+  }
+
+  @Test
+  void testSymbolicOperatorIsInfixBeforePrefixOperator() throws ParseException {
+    assertAllTokensParsedCorrectly(
+        "99 % -100",
+        new Token(1, "99", TokenType.NUMBER_LITERAL),
+        new Token(4, "%", TokenType.INFIX_OPERATOR),
+        new Token(6, "-", TokenType.PREFIX_OPERATOR),
+        new Token(7, "100", TokenType.NUMBER_LITERAL));
+  }
+
+  @Test
+  void testGroupedSymbolicOperatorIsPostfix() throws ParseException {
+    assertAllTokensParsedCorrectly(
+        "(99%) - 100",
+        new Token(1, "(", TokenType.BRACE_OPEN),
+        new Token(2, "99", TokenType.NUMBER_LITERAL),
+        new Token(4, "%", TokenType.POSTFIX_OPERATOR),
+        new Token(5, ")", TokenType.BRACE_CLOSE),
+        new Token(7, "-", TokenType.INFIX_OPERATOR),
+        new Token(9, "100", TokenType.NUMBER_LITERAL));
+  }
+
+  @Test
+  void testSymbolicOperatorIsPostfixBeforeInfixOperator() throws ParseException {
+    assertAllTokensParsedCorrectly(
+        "99 % * 100",
+        new Token(1, "99", TokenType.NUMBER_LITERAL),
+        new Token(4, "%", TokenType.POSTFIX_OPERATOR),
+        new Token(6, "*", TokenType.INFIX_OPERATOR),
+        new Token(8, "100", TokenType.NUMBER_LITERAL));
+  }
+
+  @Test
+  void testLiteralOperatorUsesSameResolution() throws ParseException {
+    assertAllTokensParsedCorrectly(
+        "99 PERCENT 100",
+        new Token(1, "99", TokenType.NUMBER_LITERAL),
+        new Token(4, "PERCENT", TokenType.INFIX_OPERATOR),
+        new Token(12, "100", TokenType.NUMBER_LITERAL));
+
+    assertAllTokensParsedCorrectly(
+        "99 PERCENT",
+        new Token(1, "99", TokenType.NUMBER_LITERAL),
+        new Token(4, "PERCENT", TokenType.POSTFIX_OPERATOR));
+
+    assertAllTokensParsedCorrectly(
+        "99 PERCENT -100",
+        new Token(1, "99", TokenType.NUMBER_LITERAL),
+        new Token(4, "PERCENT", TokenType.INFIX_OPERATOR),
+        new Token(12, "-", TokenType.PREFIX_OPERATOR),
+        new Token(13, "100", TokenType.NUMBER_LITERAL));
+  }
+
+  @Test
+  void testInvalidRightOperandDoesNotPreventPostfixResolution() {
+    assertThatThrownBy(new Tokenizer("99 % [", configuration)::parse)
+        .isInstanceOf(ParseException.class)
+        .hasMessage("Array open not allowed here");
+  }
+
+  @Test
+  void testResolvedOperatorsCanBeEvaluated() throws EvaluationException, ParseException {
+    assertThat(new Expression("99 % 100", configuration).evaluate().getNumberValue())
+        .isEqualByComparingTo("99");
+    assertThat(new Expression("99%", configuration).evaluate().getNumberValue())
+        .isEqualByComparingTo("0.99");
+    assertThat(new Expression("99%-100", configuration).evaluate().getNumberValue())
+        .isEqualByComparingTo("99");
+    assertThat(new Expression("(99%)-1", configuration).evaluate().getNumberValue())
+        .isEqualByComparingTo("-0.01");
+  }
+
+  @PostfixOperator(precedence = OPERATOR_PRECEDENCE_MULTIPLICATIVE - 1)
+  static class PostfixPercentOperator extends AbstractOperator {
+
+    @Override
+    public EvaluationValue evaluate(
+        Expression expression, Token operatorToken, EvaluationValue... operands) {
+      return EvaluationValue.numberValue(operands[0].getNumberValue().movePointLeft(2));
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- resolve operator names registered as both postfix and infix from the following expression context
- share the same resolution logic for symbolic and literal operators
- keep `OperatorDictionaryIfc` and all other public APIs unchanged
- add tokenizer and evaluation coverage for postfix, infix, prefix-RHS, grouped, invalid-lookahead, and literal-operator cases

## Root cause

After an operand, the tokenizer allowed both postfix and infix operators but always checked the postfix dictionary first. Consequently, registering a postfix `%` caused the existing modulo operator to be tokenized as postfix in expressions such as `99 % 100`. Operator precedence could not resolve this because fixity had already been selected before the shunting-yard phase.

The tokenizer now performs a one-token lookahead when both definitions exist. It selects infix when the next token can start the right operand; otherwise it selects postfix. The lookahead reuses the tokenizer's existing lexical rules and remains private implementation state.

This defines `99%-1` as modulo with a negative right operand. The postfix interpretation can be written explicitly as `(99%)-1`.

Fixes #546.

## Validation

- `mvn -Dtest=TokenizerAmbiguousOperatorTest test`
- `mvn verify` on Microsoft OpenJDK 11.0.32 (all tests, Spotless, JaCoCo 100% coverage gate, and packaging passed)