### PR TITLE
Fix overall Sonar findings

### DIFF
--- a/src/main/java/com/ezylang/evalex/data/EvaluationValue.java
+++ b/src/main/java/com/ezylang/evalex/data/EvaluationValue.java
@@ -15,6 +15,8 @@
 */
 package com.ezylang.evalex.data;
 
+import static java.util.Objects.requireNonNull;
+
 import com.ezylang.evalex.config.ExpressionConfiguration;
 import com.ezylang.evalex.parser.ASTNode;
 import java.math.BigDecimal;
@@ -411,7 +413,7 @@ public class EvaluationValue implements Comparable<EvaluationValue> {
   public Boolean getBooleanValue() {
     switch (getDataType()) {
       case NUMBER:
-        return getNumberValue().compareTo(BigDecimal.ZERO) != 0;
+        return requireNonNull(getNumberValue()).compareTo(BigDecimal.ZERO) != 0;
       case BOOLEAN:
         return (Boolean) value;
       case STRING:
@@ -531,7 +533,8 @@ public class EvaluationValue implements Comparable<EvaluationValue> {
   public int compareTo(EvaluationValue toCompare) {
     switch (getDataType()) {
       case NUMBER:
-        return getNumberValue().compareTo(toCompare.getNumberValue());
+        return requireNonNull(getNumberValue())
+            .compareTo(requireNonNull(toCompare.getNumberValue()));
       case BOOLEAN:
         return getBooleanValue().compareTo(toCompare.getBooleanValue());
       case NULL:
@@ -543,7 +546,8 @@ public class EvaluationValue implements Comparable<EvaluationValue> {
       case UNDEFINED:
         throw new NullPointerException("Can not compare an undefined value");
       default:
-        return getStringValue().compareTo(toCompare.getStringValue());
+        return requireNonNull(getStringValue())
+            .compareTo(requireNonNull(toCompare.getStringValue()));
     }
   }
 }

--- a/src/main/java/com/ezylang/evalex/functions/basic/AbsFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/basic/AbsFunction.java
@@ -15,6 +15,8 @@
 */
 package com.ezylang.evalex.functions.basic;
 
+import static java.util.Objects.requireNonNull;
+
 import com.ezylang.evalex.Expression;
 import com.ezylang.evalex.data.EvaluationValue;
 import com.ezylang.evalex.functions.AbstractFunction;
@@ -30,6 +32,7 @@ public class AbsFunction extends AbstractFunction {
       Expression expression, Token functionToken, EvaluationValue... parameterValues) {
 
     return expression.convertValue(
-        parameterValues[0].getNumberValue().abs(expression.getConfiguration().getMathContext()));
+        requireNonNull(parameterValues[0].getNumberValue())
+            .abs(expression.getConfiguration().getMathContext()));
   }
 }

--- a/src/main/java/com/ezylang/evalex/functions/basic/CeilingFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/basic/CeilingFunction.java
@@ -15,6 +15,8 @@
 */
 package com.ezylang.evalex.functions.basic;
 
+import static java.util.Objects.requireNonNull;
+
 import com.ezylang.evalex.Expression;
 import com.ezylang.evalex.data.EvaluationValue;
 import com.ezylang.evalex.functions.AbstractFunction;
@@ -31,6 +33,7 @@ public class CeilingFunction extends AbstractFunction {
 
     EvaluationValue value = parameterValues[0];
 
-    return expression.convertValue(value.getNumberValue().setScale(0, RoundingMode.CEILING));
+    return expression.convertValue(
+        requireNonNull(value.getNumberValue()).setScale(0, RoundingMode.CEILING));
   }
 }

--- a/src/main/java/com/ezylang/evalex/functions/basic/FactFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/basic/FactFunction.java
@@ -15,6 +15,8 @@
 */
 package com.ezylang.evalex.functions.basic;
 
+import static java.util.Objects.requireNonNull;
+
 import com.ezylang.evalex.EvaluationException;
 import com.ezylang.evalex.Expression;
 import com.ezylang.evalex.data.EvaluationValue;
@@ -31,7 +33,7 @@ public class FactFunction extends AbstractFunction {
   public EvaluationValue evaluate(
       Expression expression, Token functionToken, EvaluationValue... parameterValues)
       throws EvaluationException {
-    int number = parameterValues[0].getNumberValue().intValue();
+    int number = requireNonNull(parameterValues[0].getNumberValue()).intValue();
 
     int maxRecursionDepth = expression.getConfiguration().getMaxRecursionDepth();
     if (number > maxRecursionDepth) {

--- a/src/main/java/com/ezylang/evalex/functions/basic/FloorFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/basic/FloorFunction.java
@@ -15,6 +15,8 @@
 */
 package com.ezylang.evalex.functions.basic;
 
+import static java.util.Objects.requireNonNull;
+
 import com.ezylang.evalex.Expression;
 import com.ezylang.evalex.data.EvaluationValue;
 import com.ezylang.evalex.functions.AbstractFunction;
@@ -31,6 +33,7 @@ public class FloorFunction extends AbstractFunction {
 
     EvaluationValue value = parameterValues[0];
 
-    return expression.convertValue(value.getNumberValue().setScale(0, RoundingMode.FLOOR));
+    return expression.convertValue(
+        requireNonNull(value.getNumberValue()).setScale(0, RoundingMode.FLOOR));
   }
 }

--- a/src/main/java/com/ezylang/evalex/functions/basic/Log10Function.java
+++ b/src/main/java/com/ezylang/evalex/functions/basic/Log10Function.java
@@ -15,6 +15,8 @@
 */
 package com.ezylang.evalex.functions.basic;
 
+import static java.util.Objects.requireNonNull;
+
 import com.ezylang.evalex.Expression;
 import com.ezylang.evalex.data.EvaluationValue;
 import com.ezylang.evalex.functions.AbstractFunction;
@@ -28,7 +30,7 @@ public class Log10Function extends AbstractFunction {
   public EvaluationValue evaluate(
       Expression expression, Token functionToken, EvaluationValue... parameterValues) {
 
-    double d = parameterValues[0].getNumberValue().doubleValue();
+    double d = requireNonNull(parameterValues[0].getNumberValue()).doubleValue();
 
     return expression.convertDoubleValue(Math.log10(d));
   }

--- a/src/main/java/com/ezylang/evalex/functions/basic/LogFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/basic/LogFunction.java
@@ -15,6 +15,8 @@
 */
 package com.ezylang.evalex.functions.basic;
 
+import static java.util.Objects.requireNonNull;
+
 import com.ezylang.evalex.Expression;
 import com.ezylang.evalex.data.EvaluationValue;
 import com.ezylang.evalex.functions.AbstractFunction;
@@ -28,7 +30,7 @@ public class LogFunction extends AbstractFunction {
   public EvaluationValue evaluate(
       Expression expression, Token functionToken, EvaluationValue... parameterValues) {
 
-    double d = parameterValues[0].getNumberValue().doubleValue();
+    double d = requireNonNull(parameterValues[0].getNumberValue()).doubleValue();
 
     return expression.convertDoubleValue(Math.log(d));
   }

--- a/src/main/java/com/ezylang/evalex/functions/basic/RandomFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/basic/RandomFunction.java
@@ -24,12 +24,11 @@ import java.security.SecureRandom;
 /** Random function produces a random value between 0 and 1. */
 public class RandomFunction extends AbstractFunction {
 
+  private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
   @Override
   public EvaluationValue evaluate(
       Expression expression, Token functionToken, EvaluationValue... parameterValues) {
-
-    SecureRandom secureRandom = new SecureRandom();
-
-    return expression.convertDoubleValue(secureRandom.nextDouble());
+    return expression.convertDoubleValue(SECURE_RANDOM.nextDouble());
   }
 }

--- a/src/main/java/com/ezylang/evalex/functions/basic/RoundFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/basic/RoundFunction.java
@@ -15,6 +15,8 @@
 */
 package com.ezylang.evalex.functions.basic;
 
+import static java.util.Objects.requireNonNull;
+
 import com.ezylang.evalex.Expression;
 import com.ezylang.evalex.data.EvaluationValue;
 import com.ezylang.evalex.functions.AbstractFunction;
@@ -36,10 +38,9 @@ public class RoundFunction extends AbstractFunction {
     EvaluationValue precision = parameterValues[1];
 
     return expression.convertValue(
-        value
-            .getNumberValue()
+        requireNonNull(value.getNumberValue())
             .setScale(
-                precision.getNumberValue().intValue(),
+                requireNonNull(precision.getNumberValue()).intValue(),
                 expression.getConfiguration().getMathContext().getRoundingMode()));
   }
 }

--- a/src/main/java/com/ezylang/evalex/functions/basic/SqrtFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/basic/SqrtFunction.java
@@ -15,6 +15,8 @@
 */
 package com.ezylang.evalex.functions.basic;
 
+import static java.util.Objects.requireNonNull;
+
 import com.ezylang.evalex.Expression;
 import com.ezylang.evalex.data.EvaluationValue;
 import com.ezylang.evalex.functions.AbstractFunction;
@@ -40,7 +42,7 @@ public class SqrtFunction extends AbstractFunction {
      * (Ronald Mak, 2002)
      */
 
-    BigDecimal x = parameterValues[0].getNumberValue();
+    BigDecimal x = requireNonNull(parameterValues[0].getNumberValue());
     MathContext mathContext = expression.getConfiguration().getMathContext();
 
     if (x.compareTo(BigDecimal.ZERO) == 0) {

--- a/src/main/java/com/ezylang/evalex/functions/datetime/DateTimeNewFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/datetime/DateTimeNewFunction.java
@@ -15,6 +15,8 @@
 */
 package com.ezylang.evalex.functions.datetime;
 
+import static java.util.Objects.requireNonNull;
+
 import com.ezylang.evalex.EvaluationException;
 import com.ezylang.evalex.Expression;
 import com.ezylang.evalex.data.EvaluationValue;
@@ -46,7 +48,7 @@ public class DateTimeNewFunction extends AbstractFunction {
     int parameterLength = parameterValues.length;
 
     if (parameterLength == 1) {
-      BigDecimal millis = parameterValues[0].getNumberValue();
+      BigDecimal millis = requireNonNull(parameterValues[0].getNumberValue());
       return expression.convertValue(Instant.ofEpochMilli(millis.longValue()));
     }
 
@@ -58,13 +60,17 @@ public class DateTimeNewFunction extends AbstractFunction {
       parameterLength--;
     }
 
-    int year = parameterValues[0].getNumberValue().intValue();
-    int month = parameterValues[1].getNumberValue().intValue();
-    int day = parameterValues[2].getNumberValue().intValue();
-    int hour = parameterLength >= 4 ? parameterValues[3].getNumberValue().intValue() : 0;
-    int minute = parameterLength >= 5 ? parameterValues[4].getNumberValue().intValue() : 0;
-    int second = parameterLength >= 6 ? parameterValues[5].getNumberValue().intValue() : 0;
-    int nanoOfs = parameterLength == 7 ? parameterValues[6].getNumberValue().intValue() : 0;
+    int year = requireNonNull(parameterValues[0].getNumberValue()).intValue();
+    int month = requireNonNull(parameterValues[1].getNumberValue()).intValue();
+    int day = requireNonNull(parameterValues[2].getNumberValue()).intValue();
+    int hour =
+        parameterLength >= 4 ? requireNonNull(parameterValues[3].getNumberValue()).intValue() : 0;
+    int minute =
+        parameterLength >= 5 ? requireNonNull(parameterValues[4].getNumberValue()).intValue() : 0;
+    int second =
+        parameterLength >= 6 ? requireNonNull(parameterValues[5].getNumberValue()).intValue() : 0;
+    int nanoOfs =
+        parameterLength == 7 ? requireNonNull(parameterValues[6].getNumberValue()).intValue() : 0;
 
     return expression.convertValue(
         LocalDateTime.of(year, month, day, hour, minute, second, nanoOfs)

--- a/src/main/java/com/ezylang/evalex/functions/datetime/DateTimeTodayFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/datetime/DateTimeTodayFunction.java
@@ -50,7 +50,7 @@ public class DateTimeTodayFunction extends AbstractFunction {
       Expression expression, Token functionToken, EvaluationValue... parameterValues)
       throws EvaluationException {
     ZoneId zoneId = parseZoneId(expression, functionToken, parameterValues);
-    Instant today = LocalDate.now().atStartOfDay(zoneId).toInstant();
+    Instant today = LocalDate.now(zoneId).atStartOfDay(zoneId).toInstant();
     return expression.convertValue(today);
   }
 

--- a/src/main/java/com/ezylang/evalex/functions/datetime/DurationFromMillisFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/datetime/DurationFromMillisFunction.java
@@ -15,6 +15,8 @@
 */
 package com.ezylang.evalex.functions.datetime;
 
+import static java.util.Objects.requireNonNull;
+
 import com.ezylang.evalex.Expression;
 import com.ezylang.evalex.data.EvaluationValue;
 import com.ezylang.evalex.functions.AbstractFunction;
@@ -29,7 +31,7 @@ public class DurationFromMillisFunction extends AbstractFunction {
   @Override
   public EvaluationValue evaluate(
       Expression expression, Token functionToken, EvaluationValue... parameterValues) {
-    BigDecimal millis = parameterValues[0].getNumberValue();
+    BigDecimal millis = requireNonNull(parameterValues[0].getNumberValue());
     return expression.convertValue(Duration.ofMillis(millis.longValue()));
   }
 }

--- a/src/main/java/com/ezylang/evalex/functions/datetime/DurationNewFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/datetime/DurationNewFunction.java
@@ -15,6 +15,8 @@
 */
 package com.ezylang.evalex.functions.datetime;
 
+import static java.util.Objects.requireNonNull;
+
 import com.ezylang.evalex.Expression;
 import com.ezylang.evalex.data.EvaluationValue;
 import com.ezylang.evalex.functions.AbstractFunction;
@@ -36,12 +38,17 @@ public class DurationNewFunction extends AbstractFunction {
 
     int parameterLength = parameterValues.length;
 
-    int days = parameterValues[0].getNumberValue().intValue();
-    int hours = parameterLength >= 2 ? parameterValues[1].getNumberValue().intValue() : 0;
-    int minutes = parameterLength >= 3 ? parameterValues[2].getNumberValue().intValue() : 0;
-    int seconds = parameterLength >= 4 ? parameterValues[3].getNumberValue().intValue() : 0;
-    int millis = parameterLength >= 5 ? parameterValues[4].getNumberValue().intValue() : 0;
-    int nanos = parameterLength == 6 ? parameterValues[5].getNumberValue().intValue() : 0;
+    int days = requireNonNull(parameterValues[0].getNumberValue()).intValue();
+    int hours =
+        parameterLength >= 2 ? requireNonNull(parameterValues[1].getNumberValue()).intValue() : 0;
+    int minutes =
+        parameterLength >= 3 ? requireNonNull(parameterValues[2].getNumberValue()).intValue() : 0;
+    int seconds =
+        parameterLength >= 4 ? requireNonNull(parameterValues[3].getNumberValue()).intValue() : 0;
+    int millis =
+        parameterLength >= 5 ? requireNonNull(parameterValues[4].getNumberValue()).intValue() : 0;
+    int nanos =
+        parameterLength == 6 ? requireNonNull(parameterValues[5].getNumberValue()).intValue() : 0;
 
     Duration duration =
         Duration.ofDays(days)

--- a/src/main/java/com/ezylang/evalex/functions/string/StringEndsWithFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/string/StringEndsWithFunction.java
@@ -15,6 +15,8 @@
 */
 package com.ezylang.evalex.functions.string;
 
+import static java.util.Objects.requireNonNull;
+
 import com.ezylang.evalex.Expression;
 import com.ezylang.evalex.data.EvaluationValue;
 import com.ezylang.evalex.functions.AbstractFunction;
@@ -32,8 +34,8 @@ public class StringEndsWithFunction extends AbstractFunction {
   @Override
   public EvaluationValue evaluate(
       Expression expression, Token functionToken, EvaluationValue... parameterValues) {
-    String string = parameterValues[0].getStringValue();
-    String substring = parameterValues[1].getStringValue();
+    String string = requireNonNull(parameterValues[0].getStringValue());
+    String substring = requireNonNull(parameterValues[1].getStringValue());
     return expression.convertValue(string.endsWith(substring));
   }
 }

--- a/src/main/java/com/ezylang/evalex/functions/string/StringLeftFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/string/StringLeftFunction.java
@@ -15,6 +15,8 @@
 */
 package com.ezylang.evalex.functions.string;
 
+import static java.util.Objects.requireNonNull;
+
 import com.ezylang.evalex.Expression;
 import com.ezylang.evalex.data.EvaluationValue;
 import com.ezylang.evalex.functions.AbstractFunction;
@@ -55,9 +57,12 @@ public class StringLeftFunction extends AbstractFunction {
   @Override
   public EvaluationValue evaluate(
       Expression expression, Token functionToken, EvaluationValue... parameterValues) {
-    String string = parameterValues[0].getStringValue();
+    String string = requireNonNull(parameterValues[0].getStringValue());
     int length =
-        Math.max(0, Math.min(parameterValues[1].getNumberValue().intValue(), string.length()));
+        Math.max(
+            0,
+            Math.min(
+                requireNonNull(parameterValues[1].getNumberValue()).intValue(), string.length()));
     String substr = string.substring(0, length);
     return expression.convertValue(substr);
   }

--- a/src/main/java/com/ezylang/evalex/functions/string/StringLengthFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/string/StringLengthFunction.java
@@ -15,6 +15,8 @@
 */
 package com.ezylang.evalex.functions.string;
 
+import static java.util.Objects.requireNonNull;
+
 import com.ezylang.evalex.EvaluationException;
 import com.ezylang.evalex.Expression;
 import com.ezylang.evalex.data.EvaluationValue;
@@ -33,6 +35,6 @@ public class StringLengthFunction extends AbstractFunction {
   public EvaluationValue evaluate(
       Expression expression, Token functionToken, EvaluationValue... parameterValues)
       throws EvaluationException {
-    return expression.convertValue(parameterValues[0].getStringValue().length());
+    return expression.convertValue(requireNonNull(parameterValues[0].getStringValue()).length());
   }
 }

--- a/src/main/java/com/ezylang/evalex/functions/string/StringLowerFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/string/StringLowerFunction.java
@@ -15,6 +15,8 @@
 */
 package com.ezylang.evalex.functions.string;
 
+import static java.util.Objects.requireNonNull;
+
 import com.ezylang.evalex.Expression;
 import com.ezylang.evalex.data.EvaluationValue;
 import com.ezylang.evalex.functions.AbstractFunction;
@@ -27,6 +29,7 @@ public class StringLowerFunction extends AbstractFunction {
   @Override
   public EvaluationValue evaluate(
       Expression expression, Token functionToken, EvaluationValue... parameterValues) {
-    return expression.convertValue(parameterValues[0].getStringValue().toLowerCase());
+    return expression.convertValue(
+        requireNonNull(parameterValues[0].getStringValue()).toLowerCase());
   }
 }

--- a/src/main/java/com/ezylang/evalex/functions/string/StringRightFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/string/StringRightFunction.java
@@ -15,6 +15,8 @@
 */
 package com.ezylang.evalex.functions.string;
 
+import static java.util.Objects.requireNonNull;
+
 import com.ezylang.evalex.Expression;
 import com.ezylang.evalex.data.EvaluationValue;
 import com.ezylang.evalex.functions.AbstractFunction;
@@ -55,9 +57,12 @@ public class StringRightFunction extends AbstractFunction {
   @Override
   public EvaluationValue evaluate(
       Expression expression, Token functionToken, EvaluationValue... parameterValues) {
-    String string = parameterValues[0].getStringValue();
+    String string = requireNonNull(parameterValues[0].getStringValue());
     int length =
-        Math.max(0, Math.min(parameterValues[1].getNumberValue().intValue(), string.length()));
+        Math.max(
+            0,
+            Math.min(
+                requireNonNull(parameterValues[1].getNumberValue()).intValue(), string.length()));
     String substr = string.substring(string.length() - length);
     return expression.convertValue(substr);
   }

--- a/src/main/java/com/ezylang/evalex/functions/string/StringSplitFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/string/StringSplitFunction.java
@@ -15,6 +15,8 @@
 */
 package com.ezylang.evalex.functions.string;
 
+import static java.util.Objects.requireNonNull;
+
 import com.ezylang.evalex.EvaluationException;
 import com.ezylang.evalex.Expression;
 import com.ezylang.evalex.data.EvaluationValue;
@@ -45,8 +47,8 @@ public class StringSplitFunction extends AbstractFunction {
   public EvaluationValue evaluate(
       Expression expression, Token functionToken, EvaluationValue... parameterValues)
       throws EvaluationException {
-    String string = parameterValues[0].getStringValue();
-    String separator = parameterValues[1].getStringValue();
+    String string = requireNonNull(parameterValues[0].getStringValue());
+    String separator = requireNonNull(parameterValues[1].getStringValue());
     return expression.convertValue(string.split(Pattern.quote(separator)));
   }
 }

--- a/src/main/java/com/ezylang/evalex/functions/string/StringStartsWithFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/string/StringStartsWithFunction.java
@@ -15,6 +15,8 @@
 */
 package com.ezylang.evalex.functions.string;
 
+import static java.util.Objects.requireNonNull;
+
 import com.ezylang.evalex.Expression;
 import com.ezylang.evalex.data.EvaluationValue;
 import com.ezylang.evalex.functions.AbstractFunction;
@@ -32,8 +34,8 @@ public class StringStartsWithFunction extends AbstractFunction {
   @Override
   public EvaluationValue evaluate(
       Expression expression, Token functionToken, EvaluationValue... parameterValues) {
-    String string = parameterValues[0].getStringValue();
-    String substring = parameterValues[1].getStringValue();
+    String string = requireNonNull(parameterValues[0].getStringValue());
+    String substring = requireNonNull(parameterValues[1].getStringValue());
     return expression.convertValue(string.startsWith(substring));
   }
 }

--- a/src/main/java/com/ezylang/evalex/functions/string/StringSubstringFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/string/StringSubstringFunction.java
@@ -15,6 +15,8 @@
 */
 package com.ezylang.evalex.functions.string;
 
+import static java.util.Objects.requireNonNull;
+
 import com.ezylang.evalex.EvaluationException;
 import com.ezylang.evalex.Expression;
 import com.ezylang.evalex.data.EvaluationValue;
@@ -36,8 +38,8 @@ public class StringSubstringFunction extends AbstractFunction {
       throws EvaluationException {
     super.validatePreEvaluation(token, parameterValues);
     if (parameterValues.length > 2
-        && parameterValues[2].getNumberValue().intValue()
-            < parameterValues[1].getNumberValue().intValue()) {
+        && requireNonNull(parameterValues[2].getNumberValue()).intValue()
+            < requireNonNull(parameterValues[1].getNumberValue()).intValue()) {
       throw new EvaluationException(
           token, "End index must be greater than or equal to start index");
     }
@@ -47,11 +49,11 @@ public class StringSubstringFunction extends AbstractFunction {
   public EvaluationValue evaluate(
       Expression expression, Token functionToken, EvaluationValue... parameterValues)
       throws EvaluationException {
-    String string = parameterValues[0].getStringValue();
-    int start = parameterValues[1].getNumberValue().intValue();
+    String string = requireNonNull(parameterValues[0].getStringValue());
+    int start = requireNonNull(parameterValues[1].getNumberValue()).intValue();
     String result;
     if (parameterValues.length > 2) {
-      int end = parameterValues[2].getNumberValue().intValue();
+      int end = requireNonNull(parameterValues[2].getNumberValue()).intValue();
       int length = string.length();
       int finalEnd = Math.min(end, length);
       result = string.substring(start, finalEnd);

--- a/src/main/java/com/ezylang/evalex/functions/string/StringTrimFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/string/StringTrimFunction.java
@@ -15,6 +15,8 @@
 */
 package com.ezylang.evalex.functions.string;
 
+import static java.util.Objects.requireNonNull;
+
 import com.ezylang.evalex.EvaluationException;
 import com.ezylang.evalex.Expression;
 import com.ezylang.evalex.data.EvaluationValue;
@@ -33,6 +35,6 @@ public class StringTrimFunction extends AbstractFunction {
   public EvaluationValue evaluate(
       Expression expression, Token functionToken, EvaluationValue... parameterValues)
       throws EvaluationException {
-    return expression.convertValue(parameterValues[0].getStringValue().trim());
+    return expression.convertValue(requireNonNull(parameterValues[0].getStringValue()).trim());
   }
 }

--- a/src/main/java/com/ezylang/evalex/functions/string/StringUpperFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/string/StringUpperFunction.java
@@ -15,6 +15,8 @@
 */
 package com.ezylang.evalex.functions.string;
 
+import static java.util.Objects.requireNonNull;
+
 import com.ezylang.evalex.Expression;
 import com.ezylang.evalex.data.EvaluationValue;
 import com.ezylang.evalex.functions.AbstractFunction;
@@ -27,6 +29,7 @@ public class StringUpperFunction extends AbstractFunction {
   @Override
   public EvaluationValue evaluate(
       Expression expression, Token functionToken, EvaluationValue... parameterValues) {
-    return expression.convertValue(parameterValues[0].getStringValue().toUpperCase());
+    return expression.convertValue(
+        requireNonNull(parameterValues[0].getStringValue()).toUpperCase());
   }
 }

--- a/src/main/java/com/ezylang/evalex/functions/trigonometric/AcosFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/trigonometric/AcosFunction.java
@@ -16,6 +16,7 @@
 package com.ezylang.evalex.functions.trigonometric;
 
 import static java.math.BigDecimal.ONE;
+import static java.util.Objects.requireNonNull;
 
 import com.ezylang.evalex.EvaluationException;
 import com.ezylang.evalex.Expression;
@@ -33,7 +34,7 @@ public class AcosFunction extends AbstractFunction {
       Expression expression, Token functionToken, EvaluationValue... parameterValues)
       throws EvaluationException {
 
-    BigDecimal parameterValue = parameterValues[0].getNumberValue();
+    BigDecimal parameterValue = requireNonNull(parameterValues[0].getNumberValue());
 
     if (parameterValue.compareTo(ONE) > 0) {
       throw new EvaluationException(

--- a/src/main/java/com/ezylang/evalex/functions/trigonometric/AcosHFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/trigonometric/AcosHFunction.java
@@ -15,6 +15,8 @@
 */
 package com.ezylang.evalex.functions.trigonometric;
 
+import static java.util.Objects.requireNonNull;
+
 import com.ezylang.evalex.EvaluationException;
 import com.ezylang.evalex.Expression;
 import com.ezylang.evalex.data.EvaluationValue;
@@ -31,7 +33,7 @@ public class AcosHFunction extends AbstractFunction {
       throws EvaluationException {
 
     /* Formula: acosh(x) = ln(x + sqrt(x^2 - 1)) */
-    double value = parameterValues[0].getNumberValue().doubleValue();
+    double value = requireNonNull(parameterValues[0].getNumberValue()).doubleValue();
     if (Double.compare(value, 1) < 0) {
       throw new EvaluationException(functionToken, "Value must be greater or equal to one");
     }

--- a/src/main/java/com/ezylang/evalex/functions/trigonometric/AcosRFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/trigonometric/AcosRFunction.java
@@ -16,6 +16,7 @@
 package com.ezylang.evalex.functions.trigonometric;
 
 import static java.math.BigDecimal.ONE;
+import static java.util.Objects.requireNonNull;
 
 import com.ezylang.evalex.EvaluationException;
 import com.ezylang.evalex.Expression;
@@ -33,7 +34,7 @@ public class AcosRFunction extends AbstractFunction {
       Expression expression, Token functionToken, EvaluationValue... parameterValues)
       throws EvaluationException {
 
-    BigDecimal parameterValue = parameterValues[0].getNumberValue();
+    BigDecimal parameterValue = requireNonNull(parameterValues[0].getNumberValue());
 
     if (parameterValue.compareTo(ONE) > 0) {
       throw new EvaluationException(

--- a/src/main/java/com/ezylang/evalex/functions/trigonometric/AcotFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/trigonometric/AcotFunction.java
@@ -15,6 +15,8 @@
 */
 package com.ezylang.evalex.functions.trigonometric;
 
+import static java.util.Objects.requireNonNull;
+
 import com.ezylang.evalex.Expression;
 import com.ezylang.evalex.data.EvaluationValue;
 import com.ezylang.evalex.functions.AbstractFunction;
@@ -31,6 +33,7 @@ public class AcotFunction extends AbstractFunction {
     /* Formula: acot(x) = (pi / 2) - atan(x) */
     return expression.convertDoubleValue(
         Math.toDegrees(
-            (Math.PI / 2) - Math.atan(parameterValues[0].getNumberValue().doubleValue())));
+            (Math.PI / 2)
+                - Math.atan(requireNonNull(parameterValues[0].getNumberValue()).doubleValue())));
   }
 }

--- a/src/main/java/com/ezylang/evalex/functions/trigonometric/AcotHFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/trigonometric/AcotHFunction.java
@@ -15,6 +15,8 @@
 */
 package com.ezylang.evalex.functions.trigonometric;
 
+import static java.util.Objects.requireNonNull;
+
 import com.ezylang.evalex.Expression;
 import com.ezylang.evalex.data.EvaluationValue;
 import com.ezylang.evalex.functions.AbstractFunction;
@@ -29,7 +31,7 @@ public class AcotHFunction extends AbstractFunction {
       Expression expression, Token functionToken, EvaluationValue... parameterValues) {
 
     /* Formula: acoth(x) = log((x + 1) / (x - 1)) * 0.5 */
-    double value = parameterValues[0].getNumberValue().doubleValue();
+    double value = requireNonNull(parameterValues[0].getNumberValue()).doubleValue();
     return expression.convertDoubleValue(Math.log((value + 1) / (value - 1)) * 0.5);
   }
 }

--- a/src/main/java/com/ezylang/evalex/functions/trigonometric/AcotRFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/trigonometric/AcotRFunction.java
@@ -15,6 +15,8 @@
 */
 package com.ezylang.evalex.functions.trigonometric;
 
+import static java.util.Objects.requireNonNull;
+
 import com.ezylang.evalex.Expression;
 import com.ezylang.evalex.data.EvaluationValue;
 import com.ezylang.evalex.functions.AbstractFunction;
@@ -30,6 +32,7 @@ public class AcotRFunction extends AbstractFunction {
 
     /* Formula: acot(x) = (pi / 2) - atan(x) */
     return expression.convertDoubleValue(
-        (Math.PI / 2) - Math.atan(parameterValues[0].getNumberValue().doubleValue()));
+        (Math.PI / 2)
+            - Math.atan(requireNonNull(parameterValues[0].getNumberValue()).doubleValue()));
   }
 }

--- a/src/main/java/com/ezylang/evalex/functions/trigonometric/AsinFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/trigonometric/AsinFunction.java
@@ -16,6 +16,7 @@
 package com.ezylang.evalex.functions.trigonometric;
 
 import static java.math.BigDecimal.ONE;
+import static java.util.Objects.requireNonNull;
 
 import com.ezylang.evalex.EvaluationException;
 import com.ezylang.evalex.Expression;
@@ -34,7 +35,7 @@ public class AsinFunction extends AbstractFunction {
       Expression expression, Token functionToken, EvaluationValue... parameterValues)
       throws EvaluationException {
 
-    BigDecimal parameterValue = parameterValues[0].getNumberValue();
+    BigDecimal parameterValue = requireNonNull(parameterValues[0].getNumberValue());
 
     if (parameterValue.compareTo(ONE) > 0) {
       throw new EvaluationException(

--- a/src/main/java/com/ezylang/evalex/functions/trigonometric/AsinHFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/trigonometric/AsinHFunction.java
@@ -15,6 +15,8 @@
 */
 package com.ezylang.evalex.functions.trigonometric;
 
+import static java.util.Objects.requireNonNull;
+
 import com.ezylang.evalex.Expression;
 import com.ezylang.evalex.data.EvaluationValue;
 import com.ezylang.evalex.functions.AbstractFunction;
@@ -29,7 +31,7 @@ public class AsinHFunction extends AbstractFunction {
       Expression expression, Token functionToken, EvaluationValue... parameterValues) {
 
     /* Formula: asinh(x) = ln(x + sqrt(x^2 + 1)) */
-    double value = parameterValues[0].getNumberValue().doubleValue();
+    double value = requireNonNull(parameterValues[0].getNumberValue()).doubleValue();
     return expression.convertDoubleValue(Math.log(value + (Math.sqrt(Math.pow(value, 2) + 1))));
   }
 }

--- a/src/main/java/com/ezylang/evalex/functions/trigonometric/AsinRFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/trigonometric/AsinRFunction.java
@@ -17,6 +17,7 @@ package com.ezylang.evalex.functions.trigonometric;
 
 import static java.math.BigDecimal.ONE;
 import static java.math.BigDecimal.valueOf;
+import static java.util.Objects.requireNonNull;
 
 import com.ezylang.evalex.EvaluationException;
 import com.ezylang.evalex.Expression;
@@ -37,7 +38,7 @@ public class AsinRFunction extends AbstractFunction {
       Expression expression, Token functionToken, EvaluationValue... parameterValues)
       throws EvaluationException {
 
-    BigDecimal parameterValue = parameterValues[0].getNumberValue();
+    BigDecimal parameterValue = requireNonNull(parameterValues[0].getNumberValue());
 
     if (parameterValue.compareTo(ONE) > 0) {
       throw new EvaluationException(
@@ -47,7 +48,6 @@ public class AsinRFunction extends AbstractFunction {
       throw new EvaluationException(
           functionToken, "Illegal asinr(x) for x < -1: x = " + parameterValue);
     }
-    return expression.convertDoubleValue(
-        Math.asin(parameterValues[0].getNumberValue().doubleValue()));
+    return expression.convertDoubleValue(Math.asin(parameterValue.doubleValue()));
   }
 }

--- a/src/main/java/com/ezylang/evalex/functions/trigonometric/Atan2Function.java
+++ b/src/main/java/com/ezylang/evalex/functions/trigonometric/Atan2Function.java
@@ -15,6 +15,8 @@
 */
 package com.ezylang.evalex.functions.trigonometric;
 
+import static java.util.Objects.requireNonNull;
+
 import com.ezylang.evalex.Expression;
 import com.ezylang.evalex.data.EvaluationValue;
 import com.ezylang.evalex.functions.AbstractFunction;
@@ -32,7 +34,7 @@ public class Atan2Function extends AbstractFunction {
     return expression.convertDoubleValue(
         Math.toDegrees(
             Math.atan2(
-                parameterValues[0].getNumberValue().doubleValue(),
-                parameterValues[1].getNumberValue().doubleValue())));
+                requireNonNull(parameterValues[0].getNumberValue()).doubleValue(),
+                requireNonNull(parameterValues[1].getNumberValue()).doubleValue())));
   }
 }

--- a/src/main/java/com/ezylang/evalex/functions/trigonometric/Atan2RFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/trigonometric/Atan2RFunction.java
@@ -15,6 +15,8 @@
 */
 package com.ezylang.evalex.functions.trigonometric;
 
+import static java.util.Objects.requireNonNull;
+
 import com.ezylang.evalex.Expression;
 import com.ezylang.evalex.data.EvaluationValue;
 import com.ezylang.evalex.functions.AbstractFunction;
@@ -31,7 +33,7 @@ public class Atan2RFunction extends AbstractFunction {
 
     return expression.convertDoubleValue(
         Math.atan2(
-            parameterValues[0].getNumberValue().doubleValue(),
-            parameterValues[1].getNumberValue().doubleValue()));
+            requireNonNull(parameterValues[0].getNumberValue()).doubleValue(),
+            requireNonNull(parameterValues[1].getNumberValue()).doubleValue()));
   }
 }

--- a/src/main/java/com/ezylang/evalex/functions/trigonometric/AtanFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/trigonometric/AtanFunction.java
@@ -15,6 +15,8 @@
 */
 package com.ezylang.evalex.functions.trigonometric;
 
+import static java.util.Objects.requireNonNull;
+
 import com.ezylang.evalex.Expression;
 import com.ezylang.evalex.data.EvaluationValue;
 import com.ezylang.evalex.functions.AbstractFunction;
@@ -29,6 +31,7 @@ public class AtanFunction extends AbstractFunction {
       Expression expression, Token functionToken, EvaluationValue... parameterValues) {
 
     return expression.convertDoubleValue(
-        Math.toDegrees(Math.atan(parameterValues[0].getNumberValue().doubleValue())));
+        Math.toDegrees(
+            Math.atan(requireNonNull(parameterValues[0].getNumberValue()).doubleValue())));
   }
 }

--- a/src/main/java/com/ezylang/evalex/functions/trigonometric/AtanHFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/trigonometric/AtanHFunction.java
@@ -15,6 +15,8 @@
 */
 package com.ezylang.evalex.functions.trigonometric;
 
+import static java.util.Objects.requireNonNull;
+
 import com.ezylang.evalex.EvaluationException;
 import com.ezylang.evalex.Expression;
 import com.ezylang.evalex.data.EvaluationValue;
@@ -31,7 +33,7 @@ public class AtanHFunction extends AbstractFunction {
       throws EvaluationException {
 
     /* Formula: atanh(x) = 0.5*ln((1 + x)/(1 - x)) */
-    double value = parameterValues[0].getNumberValue().doubleValue();
+    double value = requireNonNull(parameterValues[0].getNumberValue()).doubleValue();
     if (Math.abs(value) >= 1) {
       throw new EvaluationException(functionToken, "Absolute value must be less than 1");
     }

--- a/src/main/java/com/ezylang/evalex/functions/trigonometric/AtanRFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/trigonometric/AtanRFunction.java
@@ -15,6 +15,8 @@
 */
 package com.ezylang.evalex.functions.trigonometric;
 
+import static java.util.Objects.requireNonNull;
+
 import com.ezylang.evalex.Expression;
 import com.ezylang.evalex.data.EvaluationValue;
 import com.ezylang.evalex.functions.AbstractFunction;
@@ -29,6 +31,6 @@ public class AtanRFunction extends AbstractFunction {
       Expression expression, Token functionToken, EvaluationValue... parameterValues) {
 
     return expression.convertDoubleValue(
-        Math.atan(parameterValues[0].getNumberValue().doubleValue()));
+        Math.atan(requireNonNull(parameterValues[0].getNumberValue()).doubleValue()));
   }
 }

--- a/src/main/java/com/ezylang/evalex/functions/trigonometric/CosFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/trigonometric/CosFunction.java
@@ -15,6 +15,8 @@
 */
 package com.ezylang.evalex.functions.trigonometric;
 
+import static java.util.Objects.requireNonNull;
+
 import com.ezylang.evalex.Expression;
 import com.ezylang.evalex.data.EvaluationValue;
 import com.ezylang.evalex.functions.AbstractFunction;
@@ -29,6 +31,7 @@ public class CosFunction extends AbstractFunction {
       Expression expression, Token functionToken, EvaluationValue... parameterValues) {
 
     return expression.convertDoubleValue(
-        Math.cos(Math.toRadians(parameterValues[0].getNumberValue().doubleValue())));
+        Math.cos(
+            Math.toRadians(requireNonNull(parameterValues[0].getNumberValue()).doubleValue())));
   }
 }

--- a/src/main/java/com/ezylang/evalex/functions/trigonometric/CosHFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/trigonometric/CosHFunction.java
@@ -15,6 +15,8 @@
 */
 package com.ezylang.evalex.functions.trigonometric;
 
+import static java.util.Objects.requireNonNull;
+
 import com.ezylang.evalex.Expression;
 import com.ezylang.evalex.data.EvaluationValue;
 import com.ezylang.evalex.functions.AbstractFunction;
@@ -29,6 +31,6 @@ public class CosHFunction extends AbstractFunction {
       Expression expression, Token functionToken, EvaluationValue... parameterValues) {
 
     return expression.convertDoubleValue(
-        Math.cosh(parameterValues[0].getNumberValue().doubleValue()));
+        Math.cosh(requireNonNull(parameterValues[0].getNumberValue()).doubleValue()));
   }
 }

--- a/src/main/java/com/ezylang/evalex/functions/trigonometric/CosRFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/trigonometric/CosRFunction.java
@@ -15,6 +15,8 @@
 */
 package com.ezylang.evalex.functions.trigonometric;
 
+import static java.util.Objects.requireNonNull;
+
 import com.ezylang.evalex.Expression;
 import com.ezylang.evalex.data.EvaluationValue;
 import com.ezylang.evalex.functions.AbstractFunction;
@@ -29,6 +31,6 @@ public class CosRFunction extends AbstractFunction {
       Expression expression, Token functionToken, EvaluationValue... parameterValues) {
 
     return expression.convertDoubleValue(
-        Math.cos(parameterValues[0].getNumberValue().doubleValue()));
+        Math.cos(requireNonNull(parameterValues[0].getNumberValue()).doubleValue()));
   }
 }

--- a/src/main/java/com/ezylang/evalex/functions/trigonometric/CotFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/trigonometric/CotFunction.java
@@ -15,6 +15,8 @@
 */
 package com.ezylang.evalex.functions.trigonometric;
 
+import static java.util.Objects.requireNonNull;
+
 import com.ezylang.evalex.Expression;
 import com.ezylang.evalex.data.EvaluationValue;
 import com.ezylang.evalex.functions.AbstractFunction;
@@ -30,6 +32,8 @@ public class CotFunction extends AbstractFunction {
 
     /* Formula: cot(x) = cos(x) / sin(x) = 1 / tan(x) */
     return expression.convertDoubleValue(
-        1 / Math.tan(Math.toRadians(parameterValues[0].getNumberValue().doubleValue())));
+        1
+            / Math.tan(
+                Math.toRadians(requireNonNull(parameterValues[0].getNumberValue()).doubleValue())));
   }
 }

--- a/src/main/java/com/ezylang/evalex/functions/trigonometric/CotHFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/trigonometric/CotHFunction.java
@@ -15,6 +15,8 @@
 */
 package com.ezylang.evalex.functions.trigonometric;
 
+import static java.util.Objects.requireNonNull;
+
 import com.ezylang.evalex.Expression;
 import com.ezylang.evalex.data.EvaluationValue;
 import com.ezylang.evalex.functions.AbstractFunction;
@@ -30,6 +32,6 @@ public class CotHFunction extends AbstractFunction {
 
     /* Formula: coth(x) = 1 / tanh(x) */
     return expression.convertDoubleValue(
-        1 / Math.tanh(parameterValues[0].getNumberValue().doubleValue()));
+        1 / Math.tanh(requireNonNull(parameterValues[0].getNumberValue()).doubleValue()));
   }
 }

--- a/src/main/java/com/ezylang/evalex/functions/trigonometric/CotRFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/trigonometric/CotRFunction.java
@@ -15,6 +15,8 @@
 */
 package com.ezylang.evalex.functions.trigonometric;
 
+import static java.util.Objects.requireNonNull;
+
 import com.ezylang.evalex.Expression;
 import com.ezylang.evalex.data.EvaluationValue;
 import com.ezylang.evalex.functions.AbstractFunction;
@@ -30,6 +32,6 @@ public class CotRFunction extends AbstractFunction {
 
     /* Formula: cot(x) = cos(x) / sin(x) = 1 / tan(x) */
     return expression.convertDoubleValue(
-        1 / Math.tan(parameterValues[0].getNumberValue().doubleValue()));
+        1 / Math.tan(requireNonNull(parameterValues[0].getNumberValue()).doubleValue()));
   }
 }

--- a/src/main/java/com/ezylang/evalex/functions/trigonometric/CscFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/trigonometric/CscFunction.java
@@ -15,6 +15,8 @@
 */
 package com.ezylang.evalex.functions.trigonometric;
 
+import static java.util.Objects.requireNonNull;
+
 import com.ezylang.evalex.Expression;
 import com.ezylang.evalex.data.EvaluationValue;
 import com.ezylang.evalex.functions.AbstractFunction;
@@ -30,6 +32,8 @@ public class CscFunction extends AbstractFunction {
 
     /* Formula: csc(x) = 1 / sin(x) */
     return expression.convertDoubleValue(
-        1 / Math.sin(Math.toRadians(parameterValues[0].getNumberValue().doubleValue())));
+        1
+            / Math.sin(
+                Math.toRadians(requireNonNull(parameterValues[0].getNumberValue()).doubleValue())));
   }
 }

--- a/src/main/java/com/ezylang/evalex/functions/trigonometric/CscHFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/trigonometric/CscHFunction.java
@@ -15,6 +15,8 @@
 */
 package com.ezylang.evalex.functions.trigonometric;
 
+import static java.util.Objects.requireNonNull;
+
 import com.ezylang.evalex.Expression;
 import com.ezylang.evalex.data.EvaluationValue;
 import com.ezylang.evalex.functions.AbstractFunction;
@@ -30,6 +32,6 @@ public class CscHFunction extends AbstractFunction {
 
     /* Formula: csch(x) = 1 / sinh(x) */
     return expression.convertDoubleValue(
-        1 / Math.sinh(parameterValues[0].getNumberValue().doubleValue()));
+        1 / Math.sinh(requireNonNull(parameterValues[0].getNumberValue()).doubleValue()));
   }
 }

--- a/src/main/java/com/ezylang/evalex/functions/trigonometric/CscRFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/trigonometric/CscRFunction.java
@@ -15,6 +15,8 @@
 */
 package com.ezylang.evalex.functions.trigonometric;
 
+import static java.util.Objects.requireNonNull;
+
 import com.ezylang.evalex.Expression;
 import com.ezylang.evalex.data.EvaluationValue;
 import com.ezylang.evalex.functions.AbstractFunction;
@@ -30,6 +32,6 @@ public class CscRFunction extends AbstractFunction {
 
     /* Formula: csc(x) = 1 / sin(x) */
     return expression.convertDoubleValue(
-        1 / Math.sin(parameterValues[0].getNumberValue().doubleValue()));
+        1 / Math.sin(requireNonNull(parameterValues[0].getNumberValue()).doubleValue()));
   }
 }

--- a/src/main/java/com/ezylang/evalex/functions/trigonometric/DegFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/trigonometric/DegFunction.java
@@ -15,6 +15,8 @@
 */
 package com.ezylang.evalex.functions.trigonometric;
 
+import static java.util.Objects.requireNonNull;
+
 import com.ezylang.evalex.Expression;
 import com.ezylang.evalex.data.EvaluationValue;
 import com.ezylang.evalex.functions.AbstractFunction;
@@ -30,7 +32,7 @@ public class DegFunction extends AbstractFunction {
   public EvaluationValue evaluate(
       Expression expression, Token functionToken, EvaluationValue... parameterValues) {
 
-    double rad = Math.toDegrees(parameterValues[0].getNumberValue().doubleValue());
+    double rad = Math.toDegrees(requireNonNull(parameterValues[0].getNumberValue()).doubleValue());
 
     return expression.convertDoubleValue(rad);
   }

--- a/src/main/java/com/ezylang/evalex/functions/trigonometric/RadFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/trigonometric/RadFunction.java
@@ -15,6 +15,8 @@
 */
 package com.ezylang.evalex.functions.trigonometric;
 
+import static java.util.Objects.requireNonNull;
+
 import com.ezylang.evalex.Expression;
 import com.ezylang.evalex.data.EvaluationValue;
 import com.ezylang.evalex.functions.AbstractFunction;
@@ -30,7 +32,7 @@ public class RadFunction extends AbstractFunction {
   public EvaluationValue evaluate(
       Expression expression, Token functionToken, EvaluationValue... parameterValues) {
 
-    double deg = Math.toRadians(parameterValues[0].getNumberValue().doubleValue());
+    double deg = Math.toRadians(requireNonNull(parameterValues[0].getNumberValue()).doubleValue());
 
     return expression.convertDoubleValue(deg);
   }

--- a/src/main/java/com/ezylang/evalex/functions/trigonometric/SecFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/trigonometric/SecFunction.java
@@ -15,6 +15,8 @@
 */
 package com.ezylang.evalex.functions.trigonometric;
 
+import static java.util.Objects.requireNonNull;
+
 import com.ezylang.evalex.Expression;
 import com.ezylang.evalex.data.EvaluationValue;
 import com.ezylang.evalex.functions.AbstractFunction;
@@ -30,6 +32,8 @@ public class SecFunction extends AbstractFunction {
 
     /* Formula: sec(x) = 1 / cos(x) */
     return expression.convertDoubleValue(
-        1 / Math.cos(Math.toRadians(parameterValues[0].getNumberValue().doubleValue())));
+        1
+            / Math.cos(
+                Math.toRadians(requireNonNull(parameterValues[0].getNumberValue()).doubleValue())));
   }
 }

--- a/src/main/java/com/ezylang/evalex/functions/trigonometric/SecHFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/trigonometric/SecHFunction.java
@@ -15,6 +15,8 @@
 */
 package com.ezylang.evalex.functions.trigonometric;
 
+import static java.util.Objects.requireNonNull;
+
 import com.ezylang.evalex.Expression;
 import com.ezylang.evalex.data.EvaluationValue;
 import com.ezylang.evalex.functions.AbstractFunction;
@@ -30,6 +32,6 @@ public class SecHFunction extends AbstractFunction {
 
     /* Formula: sech(x) = 1 / cosh(x) */
     return expression.convertDoubleValue(
-        1 / Math.cosh(parameterValues[0].getNumberValue().doubleValue()));
+        1 / Math.cosh(requireNonNull(parameterValues[0].getNumberValue()).doubleValue()));
   }
 }

--- a/src/main/java/com/ezylang/evalex/functions/trigonometric/SecRFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/trigonometric/SecRFunction.java
@@ -15,6 +15,8 @@
 */
 package com.ezylang.evalex.functions.trigonometric;
 
+import static java.util.Objects.requireNonNull;
+
 import com.ezylang.evalex.Expression;
 import com.ezylang.evalex.data.EvaluationValue;
 import com.ezylang.evalex.functions.AbstractFunction;
@@ -30,6 +32,6 @@ public class SecRFunction extends AbstractFunction {
 
     /* Formula: sec(x) = 1 / cos(x) */
     return expression.convertDoubleValue(
-        1 / Math.cos(parameterValues[0].getNumberValue().doubleValue()));
+        1 / Math.cos(requireNonNull(parameterValues[0].getNumberValue()).doubleValue()));
   }
 }

--- a/src/main/java/com/ezylang/evalex/functions/trigonometric/SinFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/trigonometric/SinFunction.java
@@ -15,6 +15,8 @@
 */
 package com.ezylang.evalex.functions.trigonometric;
 
+import static java.util.Objects.requireNonNull;
+
 import com.ezylang.evalex.Expression;
 import com.ezylang.evalex.data.EvaluationValue;
 import com.ezylang.evalex.functions.AbstractFunction;
@@ -29,6 +31,7 @@ public class SinFunction extends AbstractFunction {
       Expression expression, Token functionToken, EvaluationValue... parameterValues) {
 
     return expression.convertDoubleValue(
-        Math.sin(Math.toRadians(parameterValues[0].getNumberValue().doubleValue())));
+        Math.sin(
+            Math.toRadians(requireNonNull(parameterValues[0].getNumberValue()).doubleValue())));
   }
 }

--- a/src/main/java/com/ezylang/evalex/functions/trigonometric/SinHFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/trigonometric/SinHFunction.java
@@ -15,6 +15,8 @@
 */
 package com.ezylang.evalex.functions.trigonometric;
 
+import static java.util.Objects.requireNonNull;
+
 import com.ezylang.evalex.Expression;
 import com.ezylang.evalex.data.EvaluationValue;
 import com.ezylang.evalex.functions.AbstractFunction;
@@ -29,6 +31,6 @@ public class SinHFunction extends AbstractFunction {
       Expression expression, Token functionToken, EvaluationValue... parameterValues) {
 
     return expression.convertDoubleValue(
-        Math.sinh(parameterValues[0].getNumberValue().doubleValue()));
+        Math.sinh(requireNonNull(parameterValues[0].getNumberValue()).doubleValue()));
   }
 }

--- a/src/main/java/com/ezylang/evalex/functions/trigonometric/SinRFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/trigonometric/SinRFunction.java
@@ -15,6 +15,8 @@
 */
 package com.ezylang.evalex.functions.trigonometric;
 
+import static java.util.Objects.requireNonNull;
+
 import com.ezylang.evalex.Expression;
 import com.ezylang.evalex.data.EvaluationValue;
 import com.ezylang.evalex.functions.AbstractFunction;
@@ -29,6 +31,6 @@ public class SinRFunction extends AbstractFunction {
       Expression expression, Token functionToken, EvaluationValue... parameterValues) {
 
     return expression.convertDoubleValue(
-        Math.sin(parameterValues[0].getNumberValue().doubleValue()));
+        Math.sin(requireNonNull(parameterValues[0].getNumberValue()).doubleValue()));
   }
 }

--- a/src/main/java/com/ezylang/evalex/functions/trigonometric/TanFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/trigonometric/TanFunction.java
@@ -15,6 +15,8 @@
 */
 package com.ezylang.evalex.functions.trigonometric;
 
+import static java.util.Objects.requireNonNull;
+
 import com.ezylang.evalex.Expression;
 import com.ezylang.evalex.data.EvaluationValue;
 import com.ezylang.evalex.functions.AbstractFunction;
@@ -29,6 +31,7 @@ public class TanFunction extends AbstractFunction {
       Expression expression, Token functionToken, EvaluationValue... parameterValues) {
 
     return expression.convertDoubleValue(
-        Math.tan(Math.toRadians(parameterValues[0].getNumberValue().doubleValue())));
+        Math.tan(
+            Math.toRadians(requireNonNull(parameterValues[0].getNumberValue()).doubleValue())));
   }
 }

--- a/src/main/java/com/ezylang/evalex/functions/trigonometric/TanHFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/trigonometric/TanHFunction.java
@@ -15,6 +15,8 @@
 */
 package com.ezylang.evalex.functions.trigonometric;
 
+import static java.util.Objects.requireNonNull;
+
 import com.ezylang.evalex.Expression;
 import com.ezylang.evalex.data.EvaluationValue;
 import com.ezylang.evalex.functions.AbstractFunction;
@@ -29,6 +31,6 @@ public class TanHFunction extends AbstractFunction {
       Expression expression, Token functionToken, EvaluationValue... parameterValues) {
 
     return expression.convertDoubleValue(
-        Math.tanh(parameterValues[0].getNumberValue().doubleValue()));
+        Math.tanh(requireNonNull(parameterValues[0].getNumberValue()).doubleValue()));
   }
 }

--- a/src/main/java/com/ezylang/evalex/functions/trigonometric/TanRFunction.java
+++ b/src/main/java/com/ezylang/evalex/functions/trigonometric/TanRFunction.java
@@ -15,6 +15,8 @@
 */
 package com.ezylang.evalex.functions.trigonometric;
 
+import static java.util.Objects.requireNonNull;
+
 import com.ezylang.evalex.Expression;
 import com.ezylang.evalex.data.EvaluationValue;
 import com.ezylang.evalex.functions.AbstractFunction;
@@ -29,6 +31,6 @@ public class TanRFunction extends AbstractFunction {
       Expression expression, Token functionToken, EvaluationValue... parameterValues) {
 
     return expression.convertDoubleValue(
-        Math.tan(parameterValues[0].getNumberValue().doubleValue()));
+        Math.tan(requireNonNull(parameterValues[0].getNumberValue()).doubleValue()));
   }
 }

--- a/src/main/java/com/ezylang/evalex/operators/arithmetic/PrefixMinusOperator.java
+++ b/src/main/java/com/ezylang/evalex/operators/arithmetic/PrefixMinusOperator.java
@@ -15,6 +15,8 @@
 */
 package com.ezylang.evalex.operators.arithmetic;
 
+import static java.util.Objects.requireNonNull;
+
 import com.ezylang.evalex.EvaluationException;
 import com.ezylang.evalex.Expression;
 import com.ezylang.evalex.data.EvaluationValue;
@@ -34,7 +36,8 @@ public class PrefixMinusOperator extends AbstractOperator {
 
     if (operand.isNumberValue()) {
       return expression.convertValue(
-          operand.getNumberValue().negate(expression.getConfiguration().getMathContext()));
+          requireNonNull(operand.getNumberValue())
+              .negate(expression.getConfiguration().getMathContext()));
     } else {
       throw EvaluationException.ofUnsupportedDataTypeInOperation(operatorToken);
     }

--- a/src/main/java/com/ezylang/evalex/operators/arithmetic/PrefixPlusOperator.java
+++ b/src/main/java/com/ezylang/evalex/operators/arithmetic/PrefixPlusOperator.java
@@ -15,6 +15,8 @@
 */
 package com.ezylang.evalex.operators.arithmetic;
 
+import static java.util.Objects.requireNonNull;
+
 import com.ezylang.evalex.EvaluationException;
 import com.ezylang.evalex.Expression;
 import com.ezylang.evalex.data.EvaluationValue;
@@ -34,7 +36,8 @@ public class PrefixPlusOperator extends AbstractOperator {
 
     if (operator.isNumberValue()) {
       return expression.convertValue(
-          operator.getNumberValue().plus(expression.getConfiguration().getMathContext()));
+          requireNonNull(operator.getNumberValue())
+              .plus(expression.getConfiguration().getMathContext()));
     } else {
       throw EvaluationException.ofUnsupportedDataTypeInOperation(operatorToken);
     }

--- a/src/test/java/com/ezylang/evalex/ExpressionEvaluatorNullTest.java
+++ b/src/test/java/com/ezylang/evalex/ExpressionEvaluatorNullTest.java
@@ -22,6 +22,8 @@ import com.ezylang.evalex.parser.ParseException;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class ExpressionEvaluatorNullTest extends BaseExpressionEvaluatorTest {
 
@@ -83,6 +85,14 @@ class ExpressionEvaluatorNullTest extends BaseExpressionEvaluatorTest {
 
     Expression expression3 = createExpression("a > 5").with("a", null);
     assertThatThrownBy(expression3::evaluate).isInstanceOf(NullPointerException.class);
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {"ABS(null)", "STR_LENGTH(null)", "DT_DURATION_FROM_MILLIS(null)", "SIN(null)"})
+  void testFunctionsRejectNullValues(String expressionString) {
+    assertThatThrownBy(() -> createExpression(expressionString).evaluate())
+        .isInstanceOf(NullPointerException.class);
   }
 
   private void assertExpressionHasExpectedResult(Expression expression, String expectedResult)

--- a/src/test/java/com/ezylang/evalex/config/FunctionDictionaryIfcTest.java
+++ b/src/test/java/com/ezylang/evalex/config/FunctionDictionaryIfcTest.java
@@ -25,7 +25,9 @@ class FunctionDictionaryIfcTest {
   private final FunctionDictionaryIfc functionDictionaryIfc =
       new FunctionDictionaryIfc() {
         @Override
-        public void addFunction(String functionName, FunctionIfc function) {}
+        public void addFunction(String functionName, FunctionIfc function) {
+          // No-op: this stub only exercises the interface's default methods.
+        }
 
         @Override
         public FunctionIfc getFunction(String functionName) {

--- a/src/test/java/com/ezylang/evalex/config/OperatorDictionaryIfcTest.java
+++ b/src/test/java/com/ezylang/evalex/config/OperatorDictionaryIfcTest.java
@@ -26,7 +26,9 @@ class OperatorDictionaryIfcTest {
       new OperatorDictionaryIfc() {
 
         @Override
-        public void addOperator(String operatorString, OperatorIfc operator) {}
+        public void addOperator(String operatorString, OperatorIfc operator) {
+          // No-op: this stub only exercises the interface's default methods.
+        }
 
         @Override
         public OperatorIfc getPrefixOperator(String operatorString) {

--- a/src/test/java/com/ezylang/evalex/functions/datetime/DateTimeFunctionsTest.java
+++ b/src/test/java/com/ezylang/evalex/functions/datetime/DateTimeFunctionsTest.java
@@ -256,14 +256,15 @@ class DateTimeFunctionsTest extends BaseEvaluationTest {
 
   @Test
   void testDateTimeTodayDefaultTimeZone() throws EvaluationException, ParseException {
-    Instant expectedTime = LocalDate.now().atStartOfDay(DEFAULT_ZONE_ID).toInstant();
+    Instant expectedTime = LocalDate.now(DEFAULT_ZONE_ID).atStartOfDay(DEFAULT_ZONE_ID).toInstant();
     Instant actualTime = evaluate("DT_TODAY()").getDateTimeValue();
     assertThat(actualTime).isEqualTo(expectedTime);
   }
 
   @Test
   void testDateTimeTodayDifferentTimeZone() throws EvaluationException, ParseException {
-    Instant expectedTime = LocalDate.now().atStartOfDay(ZoneId.of("America/Sao_Paulo")).toInstant();
+    ZoneId zoneId = ZoneId.of("America/Sao_Paulo");
+    Instant expectedTime = LocalDate.now(zoneId).atStartOfDay(zoneId).toInstant();
     Instant actualTime = evaluate("DT_TODAY(\"America/Sao_Paulo\")").getDateTimeValue();
     assertThat(actualTime).isEqualTo(expectedTime);
   }

--- a/src/test/java/com/ezylang/evalex/functions/string/util/RegularExpressionUtilsTest.java
+++ b/src/test/java/com/ezylang/evalex/functions/string/util/RegularExpressionUtilsTest.java
@@ -19,7 +19,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.ezylang.evalex.functions.string.util.RegularExpressionUtils.TimeoutRegexCharSequence;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -30,57 +29,53 @@ import org.junit.jupiter.api.Test;
  */
 class RegularExpressionUtilsTest {
 
-  @Nested
-  class TimeoutRegexCharSequenceTest {
+  @Test
+  void charSequence_Length_ShouldReturnCorrectLength() {
+    String input = "OpenAI";
+    var sequence = new TimeoutRegexCharSequence(input, 1000);
 
-    @Test
-    void charSequence_Length_ShouldReturnCorrectLength() {
-      String input = "OpenAI";
-      var sequence = new TimeoutRegexCharSequence(input, 1000);
+    assertThat(sequence.length()).isEqualTo(6);
+  }
 
-      assertThat(sequence.length()).isEqualTo(6);
-    }
+  @Test
+  void charSequence_ToString_ShouldReturnOriginalStringContent() {
+    String input = "Test String";
+    var sequence = new TimeoutRegexCharSequence(input, 1000);
 
-    @Test
-    void charSequence_ToString_ShouldReturnOriginalStringContent() {
-      String input = "Test String";
-      var sequence = new TimeoutRegexCharSequence(input, 1000);
+    assertThat(sequence).hasToString("Test String");
+  }
 
-      assertThat(sequence).hasToString("Test String");
-    }
+  @Test
+  void charSequence_SubSequence_ShouldReturnValidWrappedSubSequence() {
+    // Arrange
+    String input = "Beautiful Day";
+    var originalSequence = TimeoutRegexCharSequence.withTimeoutDelta(input, 1000);
 
-    @Test
-    void charSequence_SubSequence_ShouldReturnValidWrappedSubSequence() {
-      // Arrange
-      String input = "Beautiful Day";
-      var originalSequence = TimeoutRegexCharSequence.withTimeoutDelta(input, 1000);
+    // Act
+    CharSequence subSeg = originalSequence.subSequence(0, 9);
 
-      // Act
-      CharSequence subSeg = originalSequence.subSequence(0, 9);
+    // Assert
+    assertThat(subSeg).hasToString("Beautiful");
+    assertThat(subSeg.length()).isEqualTo(9);
+    assertThat(subSeg.charAt(0)).isEqualTo('B');
+    assertThat(subSeg).isInstanceOf(TimeoutRegexCharSequence.class);
+  }
 
-      // Assert
-      assertThat(subSeg).hasToString("Beautiful");
-      assertThat(subSeg.length()).isEqualTo(9);
-      assertThat(subSeg.charAt(0)).isEqualTo('B');
-      assertThat(subSeg).isInstanceOf(TimeoutRegexCharSequence.class);
-    }
+  @Test
+  void charSequence_SubSequence_ShouldInheritTimeoutBehavior() {
+    // Arrange
+    String input = "Short-lived sequence";
+    // Force a near immediate timeout without sleeping
+    int immediateTimeout = 1; // 1 milliseconds
+    var originalSequence = new TimeoutRegexCharSequence(input, immediateTimeout);
 
-    @Test
-    void charSequence_SubSequence_ShouldInheritTimeoutBehavior() {
-      // Arrange
-      String input = "Short-lived sequence";
-      // Force a near immediate timeout without sleeping
-      int immediateTimeout = 1; // 1 milliseconds
-      var originalSequence = new TimeoutRegexCharSequence(input, immediateTimeout);
+    // Act
+    CharSequence subSeg = originalSequence.subSequence(0, 5);
 
-      // Act
-      CharSequence subSeg = originalSequence.subSequence(0, 5);
-
-      // Assert
-      // The subsequence should also throw the exception because its deadline has passed
-      assertThatThrownBy(() -> subSeg.charAt(0))
-          .isInstanceOf(IllegalStateException.class)
-          .hasMessageContaining("RegEx matching timed out");
-    }
+    // Assert
+    // The subsequence should also throw the exception because its deadline has passed
+    assertThatThrownBy(() -> subSeg.charAt(0))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("RegEx matching timed out");
   }
 }


### PR DESCRIPTION
## Summary

- make nullable numeric and string conversions explicit with `Objects.requireNonNull`, resolving the 69 `javabugs:S2259` findings while preserving EvalEx's existing `NullPointerException` contract
- reuse a single `SecureRandom` instance and evaluate `DT_TODAY` in the selected time zone
- clarify intentional no-op test stubs and flatten the regex utility tests so Sonar recognizes them
- add representative coverage for null-valued basic, string, date-time, and trigonometric functions

## Why

Issue #574 tracks 89 open findings on the overall-code Sonar dashboard. Most are caused by nullable `EvaluationValue` conversions being dereferenced intentionally, but without an explicit precondition that static analysis can recognize. The remaining actionable findings include a timezone correctness issue, repeated `SecureRandom` construction, and test-analysis false positives.

This PR addresses the 74 code-remediable findings. The remaining 15 `java:S1170` findings are Lombok `@Builder.Default` false positives in `ExpressionConfiguration`: those fields are intentionally instance fields configurable through the builder and should be accepted in Sonar rather than made static.

## Impact

The public null behavior remains unchanged: unsupported null conversions still fail with `NullPointerException`. `DT_TODAY` now derives the date in the requested/configured zone, which fixes incorrect results near cross-zone date boundaries. Random values no longer construct a new secure generator for every evaluation.

## Verification

- `mvn verify` with Java 11
- 1,273 tests passed
- Spotless check passed
- JaCoCo coverage checks passed

Refs #574