### PR TITLE
Publish a flattened consumer POM

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,10 +24,14 @@ jobs:
           java-version: '11'
           distribution: 'corretto'
           cache: maven
-      - name: Verify and analyze with SonarCloud
+      - name: Verify build and consumer POM
         ## automatic analysis is enabled in SonarCloud, so it is disabled here
         ## run: mvn --batch-mode verify sonar:sonar -Dsonar.projectKey=ezylang_EvalEx -Dsonar.organization=ezylang -Dsonar.host.url=https://sonarcloud.io -Dsonar.coverage.jacoco.xmlReportPaths=/home/runner/work/EvalEx/EvalEx/target/site/jacoco/jacoco.xml
-        run: mvn --batch-mode clean verify
+        run: |
+          mvn --batch-mode clean verify
+          test -f .flattened-pom.xml
+          ! grep -Eq '<(build|profiles|properties)>' .flattened-pom.xml
+          ! grep -q '<scope>test</scope>' .flattened-pom.xml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,8 +21,13 @@ jobs:
           server-password: MAVEN_PASSWORD
           gpg-private-key: ${{ secrets.OSSRH_GPG_SECRET_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
-      - name: build artifact
+      - name: Build artifact
         run: mvn --batch-mode clean package -Ppublish
+      - name: Verify consumer POM
+        run: |
+          test -f .flattened-pom.xml
+          ! grep -Eq '<(build|profiles|properties)>' .flattened-pom.xml
+          ! grep -q '<scope>test</scope>' .flattened-pom.xml
       - name: Create release
         uses: ncipollo/release-action@v1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 # Maven
 log/
 target/
+.flattened-pom.xml
 
 # Compiled class file
 *.class

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,33 @@
 
     <build>
         <plugins>
+            <!-- publish a consumer-focused POM without build and test configuration -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>1.8.0</version>
+                <configuration>
+                    <flattenMode>oss</flattenMode>
+                    <updatePomFile>true</updatePomFile>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>flatten</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>flatten-clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
             <!-- compile with Java 11 and use Lombok annotation processor to generate code for Lombok annotations -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Summary

- generate an OSS-mode consumer POM with `flatten-maven-plugin` during the Maven lifecycle
- make Maven install and deploy the flattened POM while preserving license, SCM, developer, and issue metadata
- verify in build and release workflows that the generated POM excludes build configuration, profiles, properties, and test dependencies
- ignore the generated `.flattened-pom.xml`

## Why

The source POM currently doubles as the published Maven Central POM, exposing test dependencies and project-only build, coverage, formatting, signing, and publishing configuration. Consumers only need resolved artifact metadata and consumer-relevant dependencies.

The generated POM is reduced from roughly 280 source lines to 45 consumer-facing lines while retaining the non-transitive Lombok `provided` dependency.

Closes #515.

## Impact

Maven Central receives a smaller consumer-focused POM. The project build remains driven by the full checked-in `pom.xml`; runtime behavior and dependency resolution are unchanged.

## Validation

- `mvn --batch-mode clean verify` — passes with 1,273 tests and all JaCoCo checks
- `mvn --batch-mode clean process-resources -Ppublish` — passes
- inspected the publish-profile `.flattened-pom.xml`: no `<build>`, `<profiles>`, `<properties>`, or test-scoped dependencies
- `git diff --check` — passes

A full local `clean package -Ppublish` reaches the existing Javadoc step and fails because the old Javadoc plugin cannot resolve the static Lombok module with the locally installed Microsoft JDK 11; the unchanged baseline fails identically.